### PR TITLE
Potential fix for code scanning alert no. 2: Missing regular expression anchor

### DIFF
--- a/internal/spotify/utils.go
+++ b/internal/spotify/utils.go
@@ -7,7 +7,7 @@ import (
 
 var alphanumericRegex = regexp.MustCompile(`^[a-zA-Z0-9]{1,50}$`)
 var spotifyUriRegex = regexp.MustCompile(`spotify:track:(\w+)`)
-var spotifyUrlRegex = regexp.MustCompile(`^https://open.spotify.com/track/(\w+)$`)
+var spotifyUrlRegex = regexp.MustCompile(`^https://open\.spotify\.com/track/(\w+)$`)
 
 // ParseTrackId parses a string and returns a spotify ID for a Spotify URL, URI, or track ID.
 func ParseTrackId(text string) *spotify.ID {

--- a/internal/spotify/utils.go
+++ b/internal/spotify/utils.go
@@ -7,7 +7,7 @@ import (
 
 var alphanumericRegex = regexp.MustCompile(`^[a-zA-Z0-9]{1,50}$`)
 var spotifyUriRegex = regexp.MustCompile(`spotify:track:(\w+)`)
-var spotifyUrlRegex = regexp.MustCompile(`^https://open\.spotify\.com/track/(\w+)$`)
+var spotifyUrlRegex = regexp.MustCompile(`^https://open\.spotify\.com/track/(\w+)(\?.*)?$`)
 
 // ParseTrackId parses a string and returns a spotify ID for a Spotify URL, URI, or track ID.
 func ParseTrackId(text string) *spotify.ID {

--- a/internal/spotify/utils.go
+++ b/internal/spotify/utils.go
@@ -7,7 +7,7 @@ import (
 
 var alphanumericRegex = regexp.MustCompile(`^[a-zA-Z0-9]{1,50}$`)
 var spotifyUriRegex = regexp.MustCompile(`spotify:track:(\w+)`)
-var spotifyUrlRegex = regexp.MustCompile(`https://open.spotify.com/track/(\w+)`)
+var spotifyUrlRegex = regexp.MustCompile(`^https://open.spotify.com/track/(\w+)$`)
 
 // ParseTrackId parses a string and returns a spotify ID for a Spotify URL, URI, or track ID.
 func ParseTrackId(text string) *spotify.ID {

--- a/internal/spotify/utils_test.go
+++ b/internal/spotify/utils_test.go
@@ -1,0 +1,21 @@
+package spotify
+
+import "testing"
+
+func TestParseTrackId_ParsesAlphanumericText(t *testing.T) {
+	// Arrange
+	text := "1234567890"
+	expected := "1234567890"
+
+	// Act
+	actual := ParseTrackId(text)
+
+	// Assert
+	if actual == nil {
+		t.Errorf("Expected %s, got nil", expected)
+	}
+
+	if actual.String() != expected {
+		t.Errorf("Expected %s, got %s", expected, actual)
+	}
+}

--- a/internal/spotify/utils_test.go
+++ b/internal/spotify/utils_test.go
@@ -3,19 +3,126 @@ package spotify
 import "testing"
 
 func TestParseTrackId_ParsesAlphanumericText(t *testing.T) {
-	// Arrange
-	text := "1234567890"
-	expected := "1234567890"
-
-	// Act
-	actual := ParseTrackId(text)
-
-	// Assert
-	if actual == nil {
-		t.Errorf("Expected %s, got nil", expected)
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"ParsesNumericText", "1234567890", "1234567890"},
+		{"ParsesAlphaText", "ABCDEFG", "ABCDEFG"},
+		{"ParsesAlphanumericText", "ABC123", "ABC123"},
 	}
 
-	if actual.String() != expected {
-		t.Errorf("Expected %s, got %s", expected, actual)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ParseTrackId(tt.input)
+			if tt.expected == "" {
+				if actual != nil {
+					t.Errorf("Expected nil, got %s", actual)
+				}
+			} else {
+				if actual == nil {
+					t.Errorf("Expected %s, got nil", tt.expected)
+				} else if actual.String() != tt.expected {
+					t.Errorf("Expected %s, got %s", tt.expected, actual)
+				}
+			}
+		})
+	}
+}
+
+func TestParseTrackId_InvalidLengthString_ReturnsNil(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"EmptyString", ""},
+		{"TooLongString", string(make([]byte, 51))},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ParseTrackId(tt.input)
+			if actual != nil {
+				t.Errorf("Expected nil, got %s", actual)
+			}
+		})
+	}
+}
+
+func TestParseTrackId_ParsesSpotifyUri(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"FirstUri", "spotify:track:4G4patpYxsF6ovHZOX9wgR", "4G4patpYxsF6ovHZOX9wgR"},
+		{"SecondUri", "spotify:track:2gQK13gXYZRq2MgvPJyHx8", "2gQK13gXYZRq2MgvPJyHx8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ParseTrackId(tt.input)
+			if tt.expected == "" {
+				if actual != nil {
+					t.Errorf("Expected nil, got %s", actual)
+				}
+			} else {
+				if actual == nil {
+					t.Errorf("Expected %s, got nil", tt.expected)
+				} else if actual.String() != tt.expected {
+					t.Errorf("Expected %s, got %s", tt.expected, actual)
+				}
+			}
+		})
+	}
+}
+
+func TestParseTrackId_DoesNotParseOtherSpotifyEntityTypeUris(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"PodcastUri", "spotify:episode:4G4patpYxsF6ovHZOX9wgR"},
+		{"AlbumUri", "spotify:album:4G4patpYxsF6ovHZOX9wgR"},
+		{"ArtistUri", "spotify:artist:4G4patpYxsF6ovHZOX9wgR"},
+		{"PlaylistUri", "spotify:playlist:4G4patpYxsF6ovHZOX9wgR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ParseTrackId(tt.input)
+			if actual != nil {
+				t.Errorf("Expected nil, got %s", actual)
+			}
+		})
+	}
+}
+
+func TestParseTrackId_ParsesSpotifyUrl(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"UrlWithQueryString", "https://open.spotify.com/track/2gQK13gXYZRq2MgvPJyHx8?si=67d66f6ee4e5494c", "2gQK13gXYZRq2MgvPJyHx8"},
+		{"UrlWithoutQueryString", "https://open.spotify.com/track/2gQK13gXYZRq2MgvPJyHx8", "2gQK13gXYZRq2MgvPJyHx8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ParseTrackId(tt.input)
+			if tt.expected == "" {
+				if actual != nil {
+					t.Errorf("Expected nil, got %s", actual)
+				}
+			} else {
+				if actual == nil {
+					t.Errorf("Expected %s, got nil", tt.expected)
+				} else if actual.String() != tt.expected {
+					t.Errorf("Expected %s, got %s", tt.expected, actual)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/VaultbotX/vaultbot-lite-v2/security/code-scanning/2](https://github.com/VaultbotX/vaultbot-lite-v2/security/code-scanning/2)

To fix the problem, we need to add anchors to the regular expression to ensure that it matches the entire URL string and not just a part of it. This can be done by adding `^` at the beginning and `$` at the end of the regular expression. This change will ensure that the regular expression only matches strings that exactly match the expected Spotify URL format.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
