### PR TITLE
Fix spotify token refresh issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/sirupsen/logrus v1.9.3
 	github.com/zmb3/spotify/v2 v2.4.3
-	golang.org/x/oauth2 v0.26.0
+	golang.org/x/oauth2 v0.28.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20210810183815-faf39c7919d5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.26.0 h1:afQXWNNaeC4nvZ0Ed9XvCCzXM6UHJG7iCg0W4fPqSBE=
 golang.org/x/oauth2 v0.26.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
+golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/persistence/postgres/conn.go
+++ b/internal/persistence/postgres/conn.go
@@ -4,9 +4,24 @@ import (
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	"os"
+	"sync"
+)
+
+var (
+	// db is the global database connection. It is perfectly fine for a sqlx.DB to be global since it
+	// simply represents a pool of connections rather than a single connection.
+	db *sqlx.DB
+	mu sync.Mutex
 )
 
 func NewPostgresConnection() (*sqlx.DB, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if db != nil {
+		return db, nil
+	}
+
 	host := os.Getenv("POSTGRES_HOST")
 	user := os.Getenv("POSTGRES_USER")
 	password := os.Getenv("POSTGRES_PASSWORD")
@@ -19,10 +34,12 @@ func NewPostgresConnection() (*sqlx.DB, error) {
 
 	dsn := "host=" + host + " user=" + user + " password=" + password + " dbname=vaultbot sslmode=disable"
 
-	db, err := sqlx.Open("postgres", dsn)
+	newDb, err := sqlx.Open("postgres", dsn)
 	if err != nil {
 		return nil, err
 	}
+
+	db = newDb
 
 	return db, nil
 }

--- a/internal/spotify/commands/artists.go
+++ b/internal/spotify/commands/artists.go
@@ -13,10 +13,6 @@ type SpotifyArtistRepo struct {
 func (r *SpotifyArtistRepo) GetArtists(artistIds []spotify.ID, artistChan chan<- *spotify.FullArtist, ctx context.Context) error {
 	r.Client.Mu.Lock()
 	defer r.Client.Mu.Unlock()
-	err := r.Client.RefreshAccessTokenIfExpired(ctx)
-	if err != nil {
-		return err
-	}
 
 	artists, err := r.Client.Client.GetArtists(ctx, artistIds...)
 	if err != nil {

--- a/internal/spotify/commands/playlists.go
+++ b/internal/spotify/commands/playlists.go
@@ -16,10 +16,6 @@ type SpotifyPlaylistRepo struct {
 func (r *SpotifyPlaylistRepo) GetPlaylistTracks(playlistItemChan chan<- *spotify.PlaylistItem, ctx context.Context) error {
 	r.Client.Mu.Lock()
 	defer r.Client.Mu.Unlock()
-	err := r.Client.RefreshAccessTokenIfExpired(ctx)
-	if err != nil {
-		return err
-	}
 
 	playlistItems, err := r.Client.Client.GetPlaylistItems(ctx, r.Client.DynamicPlaylistId)
 	if err != nil {
@@ -52,12 +48,8 @@ func (r *SpotifyPlaylistRepo) GetPlaylistTracks(playlistItemChan chan<- *spotify
 func (r *SpotifyPlaylistRepo) AddTracksToPlaylist(ctx context.Context, trackIds []spotify.ID) error {
 	r.Client.Mu.Lock()
 	defer r.Client.Mu.Unlock()
-	err := r.Client.RefreshAccessTokenIfExpired(ctx)
-	if err != nil {
-		return err
-	}
 
-	_, err = r.Client.Client.AddTracksToPlaylist(ctx, r.Client.DynamicPlaylistId, trackIds...)
+	_, err := r.Client.Client.AddTracksToPlaylist(ctx, r.Client.DynamicPlaylistId, trackIds...)
 	if err != nil {
 		return err
 	}
@@ -68,12 +60,8 @@ func (r *SpotifyPlaylistRepo) AddTracksToPlaylist(ctx context.Context, trackIds 
 func (r *SpotifyPlaylistRepo) RemoveTracksFromPlaylist(ctx context.Context, trackIds []spotify.ID) error {
 	r.Client.Mu.Lock()
 	defer r.Client.Mu.Unlock()
-	err := r.Client.RefreshAccessTokenIfExpired(ctx)
-	if err != nil {
-		return err
-	}
 
-	_, err = r.Client.Client.RemoveTracksFromPlaylist(ctx, r.Client.DynamicPlaylistId, trackIds...)
+	_, err := r.Client.Client.RemoveTracksFromPlaylist(ctx, r.Client.DynamicPlaylistId, trackIds...)
 	if err != nil {
 		return err
 	}

--- a/internal/spotify/commands/tracks.go
+++ b/internal/spotify/commands/tracks.go
@@ -14,10 +14,6 @@ type SpotifyTrackRepo struct {
 func (r *SpotifyTrackRepo) GetTrack(trackId spotify.ID, trackChan chan<- *spotify.FullTrack, ctx context.Context) error {
 	r.Client.Mu.Lock()
 	defer r.Client.Mu.Unlock()
-	err := r.Client.RefreshAccessTokenIfExpired(ctx)
-	if err != nil {
-		return err
-	}
 
 	track, err := r.Client.Client.GetTrack(ctx, trackId)
 	if err != nil {
@@ -39,10 +35,6 @@ func (r *SpotifyTrackRepo) GetTrackAudioFeatures(ctx context.Context, trackId sp
 
 	r.Client.Mu.Lock()
 	defer r.Client.Mu.Unlock()
-	err := r.Client.RefreshAccessTokenIfExpired(ctx)
-	if err != nil {
-		return err
-	}
 
 	audioFeatures, err := r.Client.Client.GetAudioFeatures(ctx, trackId)
 	if err != nil {

--- a/internal/spotify/spotify.go
+++ b/internal/spotify/spotify.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"sync"
-	"time"
 )
 
 var (
@@ -156,43 +155,6 @@ func NewSpotifyClient(ctx context.Context) (*Client, error) {
 	log.Info("Successfully retrieved new Spotify token")
 
 	return instance, nil
-}
-
-// RefreshAccessTokenIfExpired TODO: this may not be needed anymore now that we have fixed the deadline issue with the oauth2 transport
-func (c *Client) RefreshAccessTokenIfExpired(ctx context.Context) error {
-	token, err := c.Client.Token()
-	if err != nil {
-		log.Errorf("Unable to retrieve exiting token during refresh check: %v", err)
-		return err
-	}
-
-	now := time.Now()
-
-	log.WithFields(log.Fields{
-		"expiry": token.Expiry,
-		"now":    now,
-	}).Info("Checking if access token is expired")
-
-	if token.Expiry.Sub(now) > 0 {
-		log.Info("Access token is still valid")
-		return nil
-	}
-
-	log.Info("Access token expired, refreshing...")
-	newToken, err := c.auth.RefreshToken(ctx, token)
-	if err != nil {
-		return err
-	}
-
-	if newToken.AccessToken != token.AccessToken {
-		log.Info("New access token received")
-	} else {
-		log.Info("New access token is the same as the old one")
-	}
-
-	c.Client = spotify.New(c.auth.Client(ctx, newToken))
-
-	return nil
 }
 
 func validateUserPresent(ctx context.Context, client *spotify.Client) {

--- a/internal/spotify/spotify.go
+++ b/internal/spotify/spotify.go
@@ -161,6 +161,7 @@ func NewSpotifyClient(ctx context.Context) (*Client, error) {
 func (c *Client) RefreshAccessTokenIfExpired(ctx context.Context) error {
 	token, err := c.Client.Token()
 	if err != nil {
+		log.Errorf("Unable to retrieve exiting token during refresh check: %v", err)
 		return err
 	}
 

--- a/internal/spotify/spotify.go
+++ b/internal/spotify/spotify.go
@@ -71,7 +71,7 @@ func NewSpotifyClient(ctx context.Context) (*Client, error) {
 			log.Fatalf("Unable to parse Spotify token from environment variable: %s", err)
 		}
 
-		client := spotify.New(authenticator.Client(ctx, token), spotify.WithRetry(true))
+		client := spotify.New(authenticator.Client(context.Background(), token), spotify.WithRetry(true))
 
 		validateUserPresent(ctx, client)
 
@@ -158,6 +158,7 @@ func NewSpotifyClient(ctx context.Context) (*Client, error) {
 	return instance, nil
 }
 
+// RefreshAccessTokenIfExpired TODO: this may not be needed anymore now that we have fixed the deadline issue with the oauth2 transport
 func (c *Client) RefreshAccessTokenIfExpired(ctx context.Context) error {
 	token, err := c.Client.Token()
 	if err != nil {

--- a/internal/tracks/add_track.go
+++ b/internal/tracks/add_track.go
@@ -47,8 +47,8 @@ func AddTrack(input *AddTrackInput) (*spotify.FullTrack, error) {
 	go func(c chan<- error) {
 		err := input.SpTrackService.Repo.GetTrack(*convertedTrackId, trackChan, input.Ctx)
 		if err != nil {
-			close(trackChan)
 			c <- err
+			close(trackChan)
 		}
 	}(errorChan)
 


### PR DESCRIPTION
- Fix Spotify token refresh failing due to non-background context passed to singleton Spotify client constructor, causing refresh to fail due to deadline always being exceeded
- Reuse sqlx Postgres DB connection instead of creating a new connection pool on each constructor call
- Updates oauth2 dep to 0.28
- Return error from fetching a track prior to the success channel closing (handles an edge case where closing the success channel emits the `ok`, leading to the perceived handling of a different issue - one where the track does not exist rather than an error occurring)