### PR TITLE
Fix typo with Canceled

### DIFF
--- a/infra/app_platform.tf
+++ b/infra/app_platform.tf
@@ -9,7 +9,7 @@ resource "digitalocean_app" "vaultbot_app" {
     }
 
     alert {
-      rule = "DEPLOYMENT_CANCELLED"
+      rule = "DEPLOYMENT_CANCELED"
     }
 
     alert {


### PR DESCRIPTION
Follow up to #26 

Resolves this issue during tf apply:

╷
│ Error: expected spec.0.alert.0.rule to be one of [DEPLOYMENT_FAILED DEPLOYMENT_LIVE DEPLOYMENT_STARTED DEPLOYMENT_CANCELED DOMAIN_FAILED DOMAIN_LIVE], got DEPLOYMENT_CANCELLED     
│
│   with digitalocean_app.vaultbot_app,
│   on app_platform.tf line 3, in resource "digitalocean_app" "vaultbot_app":
│    3:   spec {
│
╵
