### PR TITLE
Remove autoscale since instance_count is set

### DIFF
--- a/infra/app_platform.tf
+++ b/infra/app_platform.tf
@@ -30,17 +30,6 @@ resource "digitalocean_app" "vaultbot_app" {
         window   = "TEN_MINUTES"
       }
 
-      autoscaling {
-        min_instance_count = 1
-        max_instance_count = 2
-
-        metrics {
-          cpu {
-            percent = 70
-          }
-        }
-      }
-
       env {
         key   = "POSTGRES_HOST"
         value = digitalocean_database_connection_pool.vaultbot_pool.host


### PR DESCRIPTION
Follow-up to #44 

Resolves

╷
│ Error: Error creating App: POST https://api.digitalocean.com/v2/apps: 400 (request "823db341-9828-4085-8176-0939865be76a") errors validating app spec; first error in field "services.instance_count": must not set instance_count if autoscaling is enabled
│ 
│   with digitalocean_app.vaultbot_app,
│   on app_platform.tf line 1, in resource "digitalocean_app" "vaultbot_app":
│    1: resource "digitalocean_app" "vaultbot_app" {
│ 
╵