### PR TITLE
Event source preferences

### DIFF
--- a/cmd/migration_runner/runner.go
+++ b/cmd/migration_runner/runner.go
@@ -9,10 +9,11 @@ import (
 )
 
 var (
-	migrationsList = [3]*migrations.Migration{
+	migrationsList = [4]*migrations.Migration{
 		migrations.Migration001,
 		migrations.Migration002,
 		migrations.Migration003,
+		migrations.Migration004,
 	}
 )
 

--- a/internal/persistence/postgres/migrations/migration004.go
+++ b/internal/persistence/postgres/migrations/migration004.go
@@ -1,0 +1,23 @@
+package migrations
+
+var Migration004 = &Migration{
+	Name: "004-EventSourcePreferences",
+	Up: `
+		ALTER TABLE preferences DROP CONSTRAINT preferences_pkey;
+		ALTER TABLE preferences ADD COLUMN id SERIAL PRIMARY KEY;
+		ALTER TABLE preferences ADD COLUMN start_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+		ALTER TABLE preferences ADD COLUMN end_time TIMESTAMP;
+
+		-- update the existing preference records to have the start_time equal to 
+		-- the created_date of the first song, if exists
+		UPDATE preferences
+		SET start_time = COALESCE((SELECT created_at FROM songs ORDER BY created_at LIMIT 1), CURRENT_TIMESTAMP);
+	`,
+	Down: `
+ 		ALTER TABLE preferences DROP COLUMN start_time;
+		ALTER TABLE preferences DROP COLUMN end_time;
+		ALTER TABLE preferences DROP CONSTRAINT preferences_pkey;
+		ALTER TABLE preferences DROP COLUMN id;
+		ALTER TABLE preferences ADD PRIMARY KEY (key);
+	`,
+}


### PR DESCRIPTION
- Append new preference records to the data set rather than overwriting existing ones
- Keep track of start/end times that each preference record was valid for
   - Upon setting preference value, update the end time for the current record before adding new one
- When reading preference values, always return the record with a null end time (as this indicates that it is the current)
- Migration auto-sets retroactive start dates for existing preferences equal to the earliest song addition (to aid with querying historical data)