### PR TITLE
Discord bot owner permission management

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -50,6 +50,7 @@ jobs:
           TF_VAR_spotify_client_id: ${{ secrets.SPOTIFY_CLIENT_ID }}
           TF_VAR_spotify_client_secret: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
           TF_VAR_spotify_token: ${{ secrets.SPOTIFY_TOKEN }}
+          TF_VAR_discord_administrator_user_id: ${{ secrets.DISCORD_ADMINISTRATOR_USER_ID }}
 
       - name: Apply Terraform Changes
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.plan.outcome == 'success'
@@ -66,3 +67,4 @@ jobs:
           TF_VAR_spotify_client_id: ${{ secrets.SPOTIFY_CLIENT_ID }}
           TF_VAR_spotify_client_secret: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
           TF_VAR_spotify_token: ${{ secrets.SPOTIFY_TOKEN }}
+          TF_VAR_discord_administrator_user_id: ${{ secrets.DISCORD_ADMINISTRATOR_USER_ID }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Go 1.24
-- Docker (recommended for running Postgres)
+- Docker (recommended for running Postgres and/or the whole stack via Docker Compose)
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 Set the following environment variables:
 
 - `POSTGRES_HOST`
+- `POSTGRES_PORT`
 - `POSTGRES_USER`
 - `POSTGRES_PASSWORD`
 - `DISCORD_GUILD_ID` (optional, recommended during development for immediate setting of Discord slash commands)
+- `DISCORD_ADMINISTRATOR_USER_ID` (required, this is the user ID of the bot owner)
 - `DISCORD_TOKEN` (more information below)
 - `SPOTIFY_PLAYLIST_ID` (ID of the playlist that songs will be stored in)
 - `SPOTIFY_CLIENT_ID`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       POSTGRES_PORT: "5432"
       POSTGRES_USER: ${POSTGRES_USER:?Postgres user is required}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Postgres password is required}
+      DISCORD_ADMINISTRATOR_USER_ID: ${DISCORD_ADMINISTRATOR_USER_ID:?Discord administrator user ID is required}
     depends_on:
       - postgres
       - migration_runner

--- a/infra/app_platform.tf
+++ b/infra/app_platform.tf
@@ -72,6 +72,13 @@ resource "digitalocean_app" "vaultbot_app" {
       }
 
       env {
+        key   = "DISCORD_ADMINISTRATOR_USER_ID"
+        value = var.discord_administrator_user_id
+        scope = "RUN_TIME"
+        type  = "SECRET"
+      }
+
+      env {
         key   = "SPOTIFY_PLAYLIST_ID"
         value = var.spotify_playlist_id
         scope = "RUN_TIME"

--- a/infra/project.tf
+++ b/infra/project.tf
@@ -3,6 +3,7 @@ resource "digitalocean_project" "vaultbot" {
   description = "Vaultbot Project for ${var.environment} environment"
   resources = [
     digitalocean_database_cluster.vaultbot_postgres_cluster.urn,
-    digitalocean_app.vaultbot_app.urn
+    digitalocean_app.vaultbot_app.urn,
+    digitalocean_app.vaultbot_migration_runner.urn
   ]
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -33,6 +33,12 @@ variable "discord_token" {
   sensitive   = true
 }
 
+variable "discord_administrator_user_id" {
+  type        = string
+  description = "Discord bot owner user ID"
+  sensitive   = true
+}
+
 variable "spotify_playlist_id" {
   type        = string
   description = "Spotify playlist ID"

--- a/internal/discord/helpers/check_user_permissions.go
+++ b/internal/discord/helpers/check_user_permissions.go
@@ -3,7 +3,21 @@ package helpers
 import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/vaultbotx/vaultbot-lite/internal/domain"
+	"os"
 )
+
+var (
+	administratorUserId string
+)
+
+func init() {
+	id, exists := os.LookupEnv("DISCORD_ADMINISTRATOR_USER_ID")
+	if !exists {
+		panic("DISCORD_ADMINISTRATOR_USER_ID environment variable is required")
+	}
+
+	administratorUserId = id
+}
 
 func CheckUserPermissions(s *discordgo.Session, i *discordgo.InteractionCreate) error {
 	perms, err := s.State.UserChannelPermissions(i.Member.User.ID, i.ChannelID)
@@ -12,6 +26,11 @@ func CheckUserPermissions(s *discordgo.Session, i *discordgo.InteractionCreate) 
 	}
 
 	if perms&discordgo.PermissionAdministrator == 0 {
+		return domain.ErrUnauthorized
+	}
+
+	// Secondary check to limit commands to only the bot owner for now
+	if i.Member.User.ID != administratorUserId {
 		return domain.ErrUnauthorized
 	}
 

--- a/internal/discord/helpers/check_user_permissions.go
+++ b/internal/discord/helpers/check_user_permissions.go
@@ -1,23 +1,11 @@
 package helpers
 
 import (
+	"errors"
 	"github.com/bwmarrin/discordgo"
 	"github.com/vaultbotx/vaultbot-lite/internal/domain"
 	"os"
 )
-
-var (
-	administratorUserId string
-)
-
-func init() {
-	id, exists := os.LookupEnv("DISCORD_ADMINISTRATOR_USER_ID")
-	if !exists {
-		panic("DISCORD_ADMINISTRATOR_USER_ID environment variable is required")
-	}
-
-	administratorUserId = id
-}
 
 func CheckUserPermissions(s *discordgo.Session, i *discordgo.InteractionCreate) error {
 	perms, err := s.State.UserChannelPermissions(i.Member.User.ID, i.ChannelID)
@@ -30,6 +18,11 @@ func CheckUserPermissions(s *discordgo.Session, i *discordgo.InteractionCreate) 
 	}
 
 	// Secondary check to limit commands to only the bot owner for now
+	administratorUserId, exists := os.LookupEnv("DISCORD_ADMINISTRATOR_USER_ID")
+	if !exists {
+		return errors.New("DISCORD_ADMINISTRATOR_USER_ID not set")
+	}
+
 	if i.Member.User.ID != administratorUserId {
 		return domain.ErrUnauthorized
 	}


### PR DESCRIPTION
Gate the blacklist/unblacklist and preferences commands to not only restrict to guild admins, but to solely the configured bot owner

Resolves #55 