### PR TITLE
Ensure DM specific values handled in logging_meta.go and user_fields.go

### DIFF
--- a/internal/domain/user_fields.go
+++ b/internal/domain/user_fields.go
@@ -3,5 +3,6 @@ package domain
 type UserFields struct {
 	UserId   string
 	Username string
-	GuildId  string
+	// GuildId may be empty if the user is in a direct message
+	GuildId string
 }

--- a/internal/tracks/add_track.go
+++ b/internal/tracks/add_track.go
@@ -139,7 +139,7 @@ func AddTrack(input *AddTrackInput) (*spotify.FullTrack, error) {
 	}
 
 	log.WithFields(input.Meta).Debugf("Adding track %v to database", convertedTrackId.String())
-	// 5. Add to databases
+	// 5. Add to database
 	err = input.TrackService.Repo.AddTrackToDatabase(input.UserFields, track, artists)
 	if err != nil {
 		// Compensation steps in case of failure, since the track was already added to the playlist

--- a/internal/utils/logging_meta.go
+++ b/internal/utils/logging_meta.go
@@ -11,14 +11,14 @@ func GetFieldsFromInteraction(i *discordgo.InteractionCreate) logrus.Fields {
 	if isDirectMessage {
 		return logrus.Fields{
 			"userId":          i.User.ID,
-			"username":        i.User.Username + i.User.Discriminator,
+			"username":        i.User.Username + "#" + i.User.Discriminator,
 			"isDirectMessage": isDirectMessage,
 		}
 	}
 
 	return logrus.Fields{
 		"userId":          i.Member.User.ID,
-		"username":        i.Member.User.Username + i.Member.User.Discriminator,
+		"username":        i.Member.User.Username + "#" + i.Member.User.Discriminator,
 		"guildId":         i.GuildID,
 		"isDirectMessage": isDirectMessage,
 	}

--- a/internal/utils/logging_meta.go
+++ b/internal/utils/logging_meta.go
@@ -5,10 +5,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func GetFieldsFromInteraction(interaction *discordgo.InteractionCreate) logrus.Fields {
+func GetFieldsFromInteraction(i *discordgo.InteractionCreate) logrus.Fields {
+	isDirectMessage := "" == i.GuildID
+
+	if isDirectMessage {
+		return logrus.Fields{
+			"userId":          i.User.ID,
+			"username":        i.User.Username + i.User.Discriminator,
+			"isDirectMessage": isDirectMessage,
+		}
+	}
+
 	return logrus.Fields{
-		"userId":   interaction.Member.User.ID,
-		"username": interaction.Member.User.Username + interaction.Member.User.Discriminator,
-		"guildId":  interaction.GuildID,
+		"userId":          i.Member.User.ID,
+		"username":        i.Member.User.Username + i.Member.User.Discriminator,
+		"guildId":         i.GuildID,
+		"isDirectMessage": isDirectMessage,
 	}
 }

--- a/internal/utils/user_fields.go
+++ b/internal/utils/user_fields.go
@@ -6,6 +6,16 @@ import (
 )
 
 func GetUserFieldsFromInteraction(i *discordgo.InteractionCreate) *domain.UserFields {
+	isDirectMessage := "" == i.GuildID
+
+	if isDirectMessage {
+		return &domain.UserFields{
+			UserId:   i.User.ID,
+			Username: i.User.Username,
+			GuildId:  "", // No guild ID in direct messages
+		}
+	}
+
 	return &domain.UserFields{
 		UserId:   i.Member.User.ID,
 		Username: i.Member.User.Username,


### PR DESCRIPTION
- Add support for DM slash command functionality
- Use `#` delimiter in logging between username and discriminator

Resolves #71 