### PR TITLE
Add stats dashboard with automated generation and deployment

### DIFF
--- a/.github/workflows/generate-stats.yml
+++ b/.github/workflows/generate-stats.yml
@@ -1,0 +1,52 @@
+name: Generate Stats Site
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only allow one Pages deployment at a time; cancel any in-flight run
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  generate-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.26'
+
+      - name: Build stats binary
+        run: go build -o bin/stats ./cmd/stats
+
+      - name: Generate stats JSON
+        env:
+          POSTGRES_HOST:     ${{ secrets.NEON_HOST }}
+          POSTGRES_PORT:     ${{ secrets.NEON_PORT }}
+          POSTGRES_USER:     ${{ secrets.NEON_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.NEON_PASSWORD }}
+          POSTGRES_DB:       ${{ secrets.NEON_DB }}
+        run: ./bin/stats > site/stats.json
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/cmd/stats/main.go
+++ b/cmd/stats/main.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/joho/godotenv"
+	log "github.com/sirupsen/logrus"
+	postgres "github.com/vaultbotx/vaultbot-lite/internal/persistence/postgres"
+)
+
+type MonthlyCount struct {
+	Month string `json:"month" db:"month"`
+	Count int    `json:"count" db:"count"`
+}
+
+type ArtistCount struct {
+	Name      string `json:"name" db:"name"`
+	SongCount int    `json:"song_count" db:"song_count"`
+}
+
+type GenreCount struct {
+	Name      string `json:"name" db:"name"`
+	SongCount int    `json:"song_count" db:"song_count"`
+}
+
+type Summary struct {
+	TotalSongs          int `json:"total_songs"`
+	TotalArchiveEntries int `json:"total_archive_entries"`
+	TotalArtists        int `json:"total_artists"`
+	TotalGenres         int `json:"total_genres"`
+}
+
+type Stats struct {
+	GeneratedAt       time.Time      `json:"generated_at"`
+	Summary           Summary        `json:"summary"`
+	SongsOverTime     []MonthlyCount `json:"songs_over_time"`
+	TopArtists        []ArtistCount  `json:"top_artists"`
+	GenreDistribution []GenreCount   `json:"genre_distribution"`
+}
+
+func main() {
+	log.SetFormatter(&log.JSONFormatter{})
+	// Write logs to stderr so they don't pollute the JSON written to stdout
+	log.SetOutput(os.Stderr)
+	_ = godotenv.Load()
+
+	db, err := postgres.NewPostgresConnection()
+	if err != nil {
+		log.Fatalf("Failed to connect to database: %v", err)
+	}
+
+	var stats Stats
+	stats.GeneratedAt = time.Now().UTC()
+
+	// Summary counts
+	err = db.QueryRowx(`
+		SELECT
+			(SELECT COUNT(*) FROM songs)        AS total_songs,
+			(SELECT COUNT(*) FROM song_archive) AS total_archive_entries,
+			(SELECT COUNT(*) FROM artists)      AS total_artists,
+			(SELECT COUNT(*) FROM genres)       AS total_genres
+	`).Scan(
+		&stats.Summary.TotalSongs,
+		&stats.Summary.TotalArchiveEntries,
+		&stats.Summary.TotalArtists,
+		&stats.Summary.TotalGenres,
+	)
+	if err != nil {
+		log.Fatalf("Failed to query summary: %v", err)
+	}
+
+	// Archive entries bucketed by month
+	err = db.Select(&stats.SongsOverTime, `
+		SELECT
+			TO_CHAR(DATE_TRUNC('month', created_at), 'YYYY-MM') AS month,
+			COUNT(*)                                             AS count
+		FROM song_archive
+		GROUP BY DATE_TRUNC('month', created_at)
+		ORDER BY DATE_TRUNC('month', created_at)
+	`)
+	if err != nil {
+		log.Fatalf("Failed to query songs over time: %v", err)
+	}
+
+	// Top 15 artists by unique song count
+	err = db.Select(&stats.TopArtists, `
+		SELECT a.name, COUNT(DISTINCT lsa.song_id) AS song_count
+		FROM artists a
+		JOIN link_song_artists lsa ON a.id = lsa.artist_id
+		GROUP BY a.id, a.name
+		ORDER BY song_count DESC
+		LIMIT 15
+	`)
+	if err != nil {
+		log.Fatalf("Failed to query top artists: %v", err)
+	}
+
+	// Top 30 genres by unique song count
+	err = db.Select(&stats.GenreDistribution, `
+		SELECT g.name, COUNT(DISTINCT lsg.song_id) AS song_count
+		FROM genres g
+		JOIN link_song_genres lsg ON g.id = lsg.genre_id
+		GROUP BY g.id, g.name
+		ORDER BY song_count DESC
+		LIMIT 30
+	`)
+	if err != nil {
+		log.Fatalf("Failed to query genre distribution: %v", err)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(stats); err != nil {
+		log.Fatalf("Failed to encode stats JSON: %v", err)
+	}
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vaultbot Stats</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-treemap@3.1.0/dist/chartjs-chart-treemap.min.js"></script>
+
+  <style>
+    :root {
+      --bg:           #0c0c10;
+      --surface:      #131318;
+      --surface-2:    #1a1a22;
+      --border:       #1f1f2c;
+      --text:         #e2e2f0;
+      --text-muted:   #6060a0;
+      --accent:       #7c6af7;
+      --accent-glow:  rgba(124, 106, 247, 0.12);
+      --radius:       10px;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'IBM Plex Sans', sans-serif;
+      font-size: 14px;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 32px;
+    }
+
+    header {
+      border-bottom: 1px solid var(--border);
+      padding: 28px 0;
+    }
+
+    .header-inner {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .logo-placeholder {
+      width: 44px;
+      height: 44px;
+      flex-shrink: 0;
+      border: 1px dashed var(--border);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--text-muted);
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 9px;
+      letter-spacing: 0.04em;
+      text-align: center;
+      line-height: 1.3;
+      /* replace this element with your <img src="..."> or inline <svg> */
+    }
+
+    .header-text h1 {
+      font-size: 20px;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      color: var(--text);
+    }
+
+    .header-text p {
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-top: 2px;
+    }
+
+    main {
+      padding: 40px 0 64px;
+    }
+
+    .meta {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-bottom: 36px;
+    }
+
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 16px;
+      margin-bottom: 40px;
+    }
+
+    .stat-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 22px 24px;
+    }
+
+    .stat-label {
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 10px;
+    }
+
+    .stat-value {
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 30px;
+      font-weight: 500;
+      letter-spacing: -0.03em;
+      color: var(--text);
+      line-height: 1;
+    }
+
+    .charts {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .chart-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 28px;
+    }
+
+    .chart-header {
+      margin-bottom: 24px;
+    }
+
+    .chart-title {
+      font-size: 13px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+    }
+
+    .chart-wrap { position: relative; }
+    .chart-wrap--tall    { height: 300px; }
+    .chart-wrap--medium  { height: 380px; }
+    .chart-wrap--treemap { height: 420px; }
+
+    .chart-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+    }
+
+    #loading-msg, #error-msg {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 300px;
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    #error-msg { display: none; color: #e05c6a; }
+
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 24px 0;
+      text-align: center;
+      font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px;
+      color: var(--text-muted);
+    }
+
+    @media (max-width: 900px) {
+      .summary-grid { grid-template-columns: repeat(2, 1fr); }
+      .chart-row    { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 480px) {
+      .container    { padding: 0 16px; }
+      .summary-grid { grid-template-columns: 1fr 1fr; }
+      .stat-value   { font-size: 24px; }
+    }
+  </style>
+</head>
+<body>
+
+  <header>
+    <div class="container">
+      <div class="header-inner">
+        <!-- Replace this div with your <img src="..."> or inline <svg> -->
+        <div class="logo-placeholder">LOGO</div>
+        <div class="header-text">
+          <h1>Vaultbot</h1>
+          <p>Playlist analytics</p>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <div class="container">
+      <div id="loading-msg">Loading stats&hellip;</div>
+      <div id="error-msg">Failed to load stats.json</div>
+
+      <div id="content" style="display:none">
+        <p class="meta" id="generated-at"></p>
+
+        <div class="summary-grid">
+          <div class="stat-card">
+            <div class="stat-label">Unique songs</div>
+            <div class="stat-value" id="stat-songs">&mdash;</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">Archive entries</div>
+            <div class="stat-value" id="stat-archive">&mdash;</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">Artists</div>
+            <div class="stat-value" id="stat-artists">&mdash;</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-label">Genres</div>
+            <div class="stat-value" id="stat-genres">&mdash;</div>
+          </div>
+        </div>
+
+        <div class="charts">
+          <div class="chart-card">
+            <div class="chart-header">
+              <div class="chart-title">Archive entries over time</div>
+            </div>
+            <div class="chart-wrap chart-wrap--tall">
+              <canvas id="chart-over-time"></canvas>
+            </div>
+          </div>
+
+          <div class="chart-row">
+            <div class="chart-card">
+              <div class="chart-header">
+                <div class="chart-title">Top artists</div>
+              </div>
+              <div class="chart-wrap chart-wrap--medium">
+                <canvas id="chart-artists"></canvas>
+              </div>
+            </div>
+
+            <div class="chart-card">
+              <div class="chart-header">
+                <div class="chart-title">Genre distribution</div>
+              </div>
+              <div class="chart-wrap chart-wrap--treemap">
+                <canvas id="chart-genres"></canvas>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      vaultbot &mdash; data refreshed every 6 hours
+    </div>
+  </footer>
+
+  <script>
+    Chart.defaults.color       = '#6060a0';
+    Chart.defaults.font.family = "'IBM Plex Sans', sans-serif";
+    Chart.defaults.font.size   = 12;
+    Chart.defaults.borderColor = '#1f1f2c';
+
+    function fmt(n) { return n.toLocaleString('en-US'); }
+
+    function fmtMonth(ym) {
+      const [year, month] = ym.split('-');
+      return new Date(year, parseInt(month, 10) - 1)
+        .toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+    }
+
+    const ACCENT       = '#7c6af7';
+    const ACCENT_FILL  = 'rgba(124, 106, 247, 0.12)';
+    const ACCENT_HOVER = '#9d90f9';
+
+    function treemapColor(ratio) {
+      const alpha = 0.28 + ratio * 0.62;
+      return `rgba(124, 106, 247, ${alpha.toFixed(2)})`;
+    }
+
+    function render(stats) {
+      const d = new Date(stats.generated_at);
+      document.getElementById('generated-at').textContent =
+        'Last updated ' + d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' }) +
+        ' at ' + d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZoneName: 'short' });
+
+      document.getElementById('stat-songs').textContent   = fmt(stats.summary.total_songs);
+      document.getElementById('stat-archive').textContent = fmt(stats.summary.total_archive_entries);
+      document.getElementById('stat-artists').textContent = fmt(stats.summary.total_artists);
+      document.getElementById('stat-genres').textContent  = fmt(stats.summary.total_genres);
+
+      // Archive entries over time
+      new Chart(document.getElementById('chart-over-time'), {
+        type: 'line',
+        data: {
+          labels: stats.songs_over_time.map(d => fmtMonth(d.month)),
+          datasets: [{
+            label: 'Archive entries',
+            data: stats.songs_over_time.map(d => d.count),
+            fill: true,
+            borderColor: ACCENT,
+            backgroundColor: ACCENT_FILL,
+            borderWidth: 2,
+            tension: 0.35,
+            pointRadius: 2,
+            pointHoverRadius: 5,
+            pointBackgroundColor: ACCENT,
+            pointHoverBackgroundColor: ACCENT_HOVER,
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: { mode: 'index', intersect: false },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              backgroundColor: '#1a1a22', borderColor: '#1f1f2c', borderWidth: 1,
+              titleColor: '#e2e2f0', bodyColor: '#9090c0', padding: 12
+            }
+          },
+          scales: {
+            x: {
+              grid: { color: '#1a1a24' },
+              ticks: { maxTicksLimit: 12, maxRotation: 0, font: { family: "'IBM Plex Mono', monospace", size: 11 } }
+            },
+            y: {
+              grid: { color: '#1a1a24' },
+              ticks: { font: { family: "'IBM Plex Mono', monospace", size: 11 }, callback: v => fmt(v) },
+              beginAtZero: true
+            }
+          }
+        }
+      });
+
+      // Top artists
+      const artists   = [...stats.top_artists].reverse();
+      const artistMax = stats.top_artists[0]?.song_count ?? 1;
+
+      new Chart(document.getElementById('chart-artists'), {
+        type: 'bar',
+        data: {
+          labels: artists.map(a => a.name),
+          datasets: [{
+            data: artists.map(a => a.song_count),
+            backgroundColor: artists.map(a => treemapColor(a.song_count / artistMax)),
+            borderRadius: 3,
+            borderSkipped: false,
+          }]
+        },
+        options: {
+          indexAxis: 'y',
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              backgroundColor: '#1a1a22', borderColor: '#1f1f2c', borderWidth: 1,
+              titleColor: '#e2e2f0', bodyColor: '#9090c0', padding: 12,
+              callbacks: { label: ctx => ` ${fmt(ctx.parsed.x)} song${ctx.parsed.x !== 1 ? 's' : ''}` }
+            }
+          },
+          scales: {
+            x: {
+              grid: { color: '#1a1a24' },
+              ticks: { font: { family: "'IBM Plex Mono', monospace", size: 11 }, callback: v => fmt(v) },
+              beginAtZero: true
+            },
+            y: { grid: { display: false }, ticks: { font: { size: 12 }, color: '#b0b0d0' } }
+          }
+        }
+      });
+
+      // Genre treemap
+      const genreMax = stats.genre_distribution[0]?.song_count ?? 1;
+
+      new Chart(document.getElementById('chart-genres'), {
+        type: 'treemap',
+        data: {
+          datasets: [{
+            tree: stats.genre_distribution,
+            key: 'song_count',
+            labels: {
+              display: true,
+              align: 'center',
+              position: 'middle',
+              color: 'rgba(226, 226, 240, 0.90)',
+              font: [
+                { family: "'IBM Plex Mono', monospace", size: 11, weight: '500' },
+                { family: "'IBM Plex Mono', monospace", size: 10 }
+              ],
+              formatter: ctx => {
+                const d = ctx.raw._data;
+                return [d.name, fmt(d.song_count)];
+              }
+            },
+            backgroundColor: ctx => {
+              if (ctx.type !== 'data') return 'transparent';
+              const ratio = (ctx.raw._data?.song_count ?? 0) / genreMax;
+              return treemapColor(ratio);
+            },
+            borderColor: '#0c0c10',
+            borderWidth: 2,
+            spacing: 1,
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              backgroundColor: '#1a1a22', borderColor: '#1f1f2c', borderWidth: 1,
+              titleColor: '#e2e2f0', bodyColor: '#9090c0', padding: 12,
+              callbacks: {
+                title: items => items[0].raw._data.name,
+                label: item  => ` ${fmt(item.raw._data.song_count)} song${item.raw._data.song_count !== 1 ? 's' : ''}`
+              }
+            }
+          }
+        }
+      });
+    }
+
+    fetch('./stats.json')
+      .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
+      .then(stats => {
+        document.getElementById('loading-msg').style.display = 'none';
+        document.getElementById('content').style.display     = 'block';
+        render(stats);
+      })
+      .catch(() => {
+        document.getElementById('loading-msg').style.display = 'none';
+        document.getElementById('error-msg').style.display   = 'flex';
+      });
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds a complete analytics dashboard for Vaultbot that displays playlist statistics and is automatically generated and deployed to GitHub Pages every 6 hours.

## Key Changes

- **Stats Generation CLI** (`cmd/stats/main.go`): New Go command that queries the PostgreSQL database and generates a JSON file containing:
  - Summary metrics (total songs, archive entries, artists, genres)
  - Monthly archive entry counts for trend visualization
  - Top 15 artists by unique song count
  - Top 30 genres by unique song count

- **Dashboard UI** (`site/index.html`): A responsive, dark-themed analytics dashboard featuring:
  - Summary stat cards displaying key metrics
  - Line chart showing archive entries over time
  - Horizontal bar chart of top artists
  - Treemap visualization of genre distribution
  - Graceful loading and error states
  - Mobile-responsive design with breakpoints for tablets and phones

- **Automated Workflow** (`.github/workflows/generate-stats.yml`): GitHub Actions workflow that:
  - Runs on a 6-hour schedule (configurable via `workflow_dispatch`)
  - Builds the stats binary
  - Queries the Neon PostgreSQL database using secrets
  - Generates `stats.json` and deploys to GitHub Pages
  - Uses proper concurrency controls to prevent simultaneous deployments

## Implementation Details

- The stats CLI writes logs to stderr and JSON output to stdout for clean separation
- Database queries use efficient GROUP BY aggregations with DISTINCT counts
- Chart.js and chartjs-chart-treemap libraries provide interactive visualizations
- Color scheme uses a cohesive dark purple palette with proper contrast for accessibility
- The dashboard fetches `stats.json` client-side and renders charts dynamically
- All timestamps are in UTC for consistency

https://claude.ai/code/session_01NQiNBPBZWruVGoz5x6nHun