### PR TITLE
Limit throwback playlist to top 100 tracks per Spotify API cap

### DIFF
--- a/internal/persistence/postgres/songs/songs.go
+++ b/internal/persistence/postgres/songs/songs.go
@@ -166,7 +166,8 @@ func GetTopSongsByYear(db *sqlx.DB, minCount int) ([]Song, int, error) {
 		         JOIN songs s ON sa.song_id = s.id
 		WHERE EXTRACT(YEAR FROM s.release_date)::int = $1
 		GROUP BY s.id
-		ORDER BY COUNT(sa.id) DESC;
+		ORDER BY COUNT(sa.id) DESC
+		LIMIT 100;
 	`, year)
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
GetTopSongsByYear now applies LIMIT 100 (ordered by archive count DESC), matching the existing cap in GetTopSongsByGenre and keeping the result within Spotify's 100-track-per-AddTracksToPlaylist limit.

https://claude.ai/code/session_018JbdfN7H3bCgGnuDwaEsjX

Follow-up to #128