### PR TITLE
Select throwback year randomly, not by highest track count

### DIFF
--- a/internal/cron/populate_throwback_playlist.go
+++ b/internal/cron/populate_throwback_playlist.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	throwbackMinTrackCount          = 20
-	baseThrowbackPlaylistDescription = "The best tracks from a single release year, as voted by the Vaultbot community."
+	baseThrowbackPlaylistDescription = "A randomly selected release year tracked by Vaultbot."
 )
 
 func RunPopulateThrowbackPlaylist(ctx context.Context) error {

--- a/internal/persistence/postgres/songs/songs.go
+++ b/internal/persistence/postgres/songs/songs.go
@@ -141,7 +141,7 @@ func GetTopSongsByYear(db *sqlx.DB, minCount int) ([]Song, int, error) {
 		         JOIN songs s ON sa.song_id = s.id
 		GROUP BY release_year
 		HAVING COUNT(sa.id) >= $1
-		ORDER BY COUNT(sa.id) DESC
+		ORDER BY RANDOM()
 		LIMIT 1;
 	`, minCount).Scan(&year)
 	if err != nil {


### PR DESCRIPTION
Mirrors GetRandomGenre: picks a random year from those meeting the minimum threshold rather than always returning the same top year.

https://claude.ai/code/session_018JbdfN7H3bCgGnuDwaEsjX

Fix following #129