### PR TITLE
feat: CI/CD pipeline for SvelteKit frontend

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,13 +2,13 @@ name: Claude Code
 
 on:
   issue_comment:
-    types: [created]
+    types: [ created ]
   pull_request_review_comment:
-    types: [created]
+    types: [ created ]
   issues:
-    types: [opened, assigned]
+    types: [ opened, assigned ]
   pull_request_review:
-    types: [submitted]
+    types: [ submitted ]
 
 jobs:
   claude:

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [ closed ]
 
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,57 @@
+name: Cleanup Preview
+
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Cloudflare Pages preview deployments
+        uses: actions/github-script@v7
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        with:
+          script: |
+            const branch = `pr-${context.issue.number}`;
+            const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+            const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+            const projectName = 'vaultbot';
+            const baseUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/pages/projects/${projectName}/deployments`;
+            const headers = { 'Authorization': `Bearer ${apiToken}` };
+
+            let page = 1;
+            const deploymentIds = [];
+            while (true) {
+              const res = await fetch(`${baseUrl}?page=${page}&per_page=25`, { headers });
+              const data = await res.json();
+              if (!data.success) {
+                core.setFailed(`Failed to list deployments: ${JSON.stringify(data.errors)}`);
+                return;
+              }
+              for (const d of data.result) {
+                if (d.deployment_trigger?.metadata?.branch === branch) {
+                  deploymentIds.push(d.id);
+                }
+              }
+              if (data.result.length < 25) break;
+              page++;
+            }
+
+            if (deploymentIds.length === 0) {
+              core.info(`No deployments found for branch ${branch} — nothing to clean up.`);
+              return;
+            }
+
+            core.info(`Found ${deploymentIds.length} deployment(s) for branch ${branch}. Deleting...`);
+            for (const id of deploymentIds) {
+              const res = await fetch(`${baseUrl}/${id}?force=true`, { method: 'DELETE', headers });
+              const data = await res.json();
+              if (!data.success) {
+                core.warning(`Failed to delete deployment ${id}: ${JSON.stringify(data.errors)}`);
+              } else {
+                core.info(`Deleted deployment ${id}`);
+              }
+            }

--- a/.github/workflows/curated-playlists.yml
+++ b/.github/workflows/curated-playlists.yml
@@ -2,7 +2,7 @@ name: Curated Playlists
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26'
+          go-version: "1.26"
 
       - name: Build
         run: go build -o bin/genre ./cmd/genre
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26'
+          go-version: "1.26"
 
       - name: Build
         run: go build -o bin/highscores ./cmd/highscores
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26'
+          go-version: "1.26"
 
       - name: Build
         run: go build -o bin/throwback ./cmd/throwback
@@ -107,7 +107,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26'
+          go-version: "1.26"
 
       - name: Build
         run: go build -o bin/variety ./cmd/variety

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy Web
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ "web/**" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Set DATABASE_URL secret on Cloudflare Pages
+        run: echo "${{ secrets.CF_PAGES_DATABASE_URL }}" | npx wrangler pages secret put
+          DATABASE_URL --project-name=vaultbot
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          workingDirectory: web
+          command: pages deploy .svelte-kit/cloudflare --project-name=vaultbot

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,31 +1,29 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Go
 
 on:
   push:
     branches: [ "main" ]
+    paths-ignore: [ "web/**" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore: [ "web/**" ]
 
 permissions:
   contents: read
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.26'
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.26"
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [ "main" ]
     paths:
-      - 'internal/persistence/postgres/migrations/**'
-      - 'cmd/migration_runner/**'
+      - "internal/persistence/postgres/migrations/**"
+      - "cmd/migration_runner/**"
   workflow_dispatch:
 
 permissions:
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26'
+          go-version: "1.26"
 
       - name: Build
         run: go build -o bin/migration_runner ./cmd/migration_runner

--- a/.github/workflows/poll.yml
+++ b/.github/workflows/poll.yml
@@ -2,7 +2,7 @@ name: Poll Playlist
 
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: "0 */6 * * *"
   workflow_dispatch:
 
 permissions:
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26'
+          go-version: "1.26"
 
       - name: Build
         run: go build -o bin/poll ./cmd/poll

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,101 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths: [ "web/**" ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run check
+
+      - name: Build
+        run: npm run build
+
+  deploy-preview:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy preview to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          workingDirectory: web
+          command: pages deploy .svelte-kit/cloudflare --project-name=vaultbot
+            --branch=pr-${{ github.event.pull_request.number }}
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- cf-pages-preview -->';
+            const url = '${{ steps.deploy.outputs.deployment-url }}';
+            const sha = context.payload.pull_request.head.sha;
+            const shortSha = sha.slice(0, 7);
+            const timestamp = new Date().toUTCString();
+            const body = `${marker}\n🚀 Preview deployed: ${url}\n\n| | |\n|---|---|\n| **Commit** | \`${shortSha}\` |\n| **Last deployed** | ${timestamp} |`;
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.data.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: web

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -2,7 +2,7 @@ name: Purge Expired Tracks
 
 on:
   schedule:
-    - cron: '0 0,12 * * *'
+    - cron: "0 0,12 * * *"
   workflow_dispatch:
 
 permissions:
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26'
+          go-version: "1.26"
 
       - name: Build
         run: go build -o bin/purge ./cmd/purge

--- a/.github/workflows/refresh-graph.yml
+++ b/.github/workflows/refresh-graph.yml
@@ -2,7 +2,7 @@ name: Refresh Genre Graph
 
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: "0 */6 * * *"
   workflow_dispatch:
 
 permissions:
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.26'
+          go-version: "1.26"
 
       - name: Build
         run: go build -o bin/refresh_graph_mv ./cmd/refresh_graph_mv

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .svelte-kit/
 build/
 .dev.vars
+.wrangler/


### PR DESCRIPTION
## Summary

- Adds `pr-validation.yml` — on PRs to `main` touching `web/**`: lint (blocking) → type check → build → deploy Cloudflare Pages preview → post/update preview URL comment on PR
- Adds `deploy.yml` — on merge to `main` touching `web/**`: build → set `DATABASE_URL` secret on Cloudflare Pages via wrangler → deploy production
- Adds `cleanup-preview.yml` — on PR close: deletes all Cloudflare Pages preview deployments for `pr-{N}` branch
- Updates `go.yml` — adds `paths-ignore: ["web/**"]` so Go CI skips frontend-only changes
- Fixes `.wrangler/` gitignore in `web/`

## Secrets required in repo settings

| Secret | Purpose |
|---|---|
| `CLOUDFLARE_API_TOKEN` | Cloudflare API token with Pages:Edit permission |
| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID |
| `CF_PAGES_DATABASE_URL` | Neon production connection string, set as Pages secret on each deploy |

## Test plan

- [x] Open a PR touching a file in `web/` — validate + deploy-preview jobs should run; preview URL comment should appear
- [ ] Open a PR touching only Go files — `pr-validation.yml` should not trigger; `go.yml` should
- [ ] Merge a PR touching `web/` — `deploy.yml` should run and deploy to production
- [ ] Close a PR that had a preview — `cleanup-preview.yml` should delete the preview deployment

https://claude.ai/code/session_01E4z7e4sUKwaZr6ArsrxQ4r