### PR TITLE
Add Cloudflare account ID to deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Set DATABASE_URL secret on Cloudflare Pages
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: echo "${{ secrets.CF_PAGES_DATABASE_URL }}" | npx wrangler pages secret put
           DATABASE_URL --project-name=vaultbot
 


### PR DESCRIPTION
Attempt to prevent the following Wrangler error:

```
 ✘ [ERROR] A request to the Cloudflare API (/memberships) failed.
  Authentication failed (status: 400) [code: 9106]
```

by including account ID in the environment so that the discovery call is unnecessary