### PR TITLE
feat: graph visualization and genre drilldown UI

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Set DATABASE_URL secret for Cloudflare Pages preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: echo "${{ secrets.CF_PAGES_DATABASE_URL }}" | npx wrangler pages secret put
+          DATABASE_URL --project-name=vaultbot --env preview
+
       - name: Deploy preview to Cloudflare Pages
         id: deploy
         uses: cloudflare/wrangler-action@v3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,36 @@ var Migration0NN = &Migration{
 
 2. Register it in `cmd/migration_runner/runner.go` — increment the array size and append the variable.
 
+## TypeScript conventions
+
+**Use types as strictly as possible. Avoid `any` and avoid `as unknown as T` unless there is no other option.**
+
+### Parallel DB queries — always use `allNamed` + `typed`
+
+`Promise.all` with positional destructuring is fragile: inserting or reordering a query silently mismatches results to variable names with no compile-time error. Always use the helpers in `web/src/lib/allNamed.ts` instead:
+
+```typescript
+import { allNamed, typed } from "$lib/allNamed";
+
+const { genreRows, artists } = await allNamed({
+  genreRows: typed<{ name: string }[]>(sql`SELECT name FROM genres WHERE id = ${id}`),
+  artists:   typed<Artist[]>(sql`SELECT name FROM artists WHERE ...`),
+});
+```
+
+- **`allNamed`** — runs promises in parallel keyed by name; position in the object is irrelevant.
+- **`typed<T>`** — the single approved boundary cast for neon query results. The neon template tag returns `NeonQueryPromise<…, Record<string,any>[]>` which TypeScript 6 will not let you narrow with a plain `as`. `typed<T>` confines the required `as unknown as` to one documented location.
+
+Never scatter `as unknown as SomeType` across route files. If a new external boundary needs a cast, add a named helper like `typed` rather than inlining it.
+
+### `satisfies` for return shapes
+
+Use `satisfies` (not `as`) when asserting that a value matches an interface at a return site — it checks the shape without widening the type:
+
+```typescript
+return json({ vertices, edges } satisfies GraphData, { headers: { … } });
+```
+
 ## Svelte 5 patterns
 
 Use runes throughout. No `$:` reactive declarations, no `export let`.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@neondatabase/serverless": "1.1.0",
-				"cytoscape": "3.33.2"
+				"cytoscape": "3.33.2",
+				"cytoscape-fcose": "2.2.0"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.4.11",
@@ -1981,6 +1982,15 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/cose-base": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+			"integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+			"license": "MIT",
+			"dependencies": {
+				"layout-base": "^2.0.0"
+			}
+		},
 		"node_modules/cytoscape": {
 			"version": "3.33.2",
 			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
@@ -1988,6 +1998,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10"
+			}
+		},
+		"node_modules/cytoscape-fcose": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+			"integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"cose-base": "^2.2.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
 			}
 		},
 		"node_modules/deepmerge": {
@@ -2148,6 +2170,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/layout-base": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+			"integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+			"license": "MIT"
 		},
 		"node_modules/lightningcss": {
 			"version": "1.32.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "vaultbot-web",
 			"version": "0.0.1",
 			"dependencies": {
-				"@neondatabase/serverless": "1.1.0"
+				"@neondatabase/serverless": "1.1.0",
+				"cytoscape": "3.33.2"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.4.11",
@@ -1978,6 +1979,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cytoscape": {
+			"version": "3.33.2",
+			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+			"integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/deepmerge": {

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
 	},
 	"dependencies": {
 		"@neondatabase/serverless": "1.1.0",
-		"cytoscape": "3.33.2"
+		"cytoscape": "3.33.2",
+		"cytoscape-fcose": "2.2.0"
 	}
 }

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
 		"vite": "8.0.9"
 	},
 	"dependencies": {
-		"@neondatabase/serverless": "1.1.0"
+		"@neondatabase/serverless": "1.1.0",
+		"cytoscape": "3.33.2"
 	}
 }

--- a/web/src/cytoscape-fcose.d.ts
+++ b/web/src/cytoscape-fcose.d.ts
@@ -1,0 +1,5 @@
+declare module "cytoscape-fcose" {
+	import type cytoscape from "cytoscape";
+	const fcose: cytoscape.Ext;
+	export default fcose;
+}

--- a/web/src/lib/allNamed.ts
+++ b/web/src/lib/allNamed.ts
@@ -1,0 +1,33 @@
+/**
+ * Runs promises in parallel (like Promise.all) but accepts a named object
+ * instead of an array, so results are keyed by name rather than by position.
+ * This prevents destructuring order bugs when adding or reordering queries.
+ *
+ * @example
+ * const { users, posts } = await allNamed({
+ *   users: fetchUsers(),
+ *   posts: fetchPosts(),
+ * });
+ */
+export async function allNamed<T extends Record<string, Promise<unknown>>>(
+	queries: T,
+): Promise<{ [K in keyof T]: Awaited<T[K]> }> {
+	const keys = Object.keys(queries) as (keyof T & string)[];
+	const values = await Promise.all(keys.map((k) => queries[k]));
+	return Object.fromEntries(keys.map((k, i) => [k, values[i]])) as {
+		[K in keyof T]: Awaited<T[K]>;
+	};
+}
+
+/**
+ * Asserts the type of a database query result at the system boundary.
+ * The neon template tag returns Record<string,any>[] which cannot be cast
+ * directly to a concrete interface in TypeScript 6 — this helper confines
+ * the necessary `as unknown as` cast to a single, documented location.
+ *
+ * @example
+ * typed<User[]>(sql`SELECT id, name FROM users`)
+ */
+export function typed<T>(promise: Promise<unknown>): Promise<T> {
+	return promise as unknown as Promise<T>;
+}

--- a/web/src/lib/louvain.ts
+++ b/web/src/lib/louvain.ts
@@ -1,0 +1,93 @@
+// Louvain community detection (phase 1 greedy modularity maximization)
+// Returns a map from nodeId → community index (0-based consecutive integers)
+export function detectCommunities(
+	nodeIds: number[],
+	edges: { source: number; target: number; weight: number }[],
+): Map<number, number> {
+	const n = nodeIds.length;
+	if (n === 0) return new Map();
+
+	const idx = new Map<number, number>(nodeIds.map((id, i) => [id, i]));
+
+	const adj: Map<number, number>[] = Array.from({ length: n }, () => new Map());
+	let m = 0;
+
+	for (const { source, target, weight } of edges) {
+		const s = idx.get(source);
+		const t = idx.get(target);
+		if (s === undefined || t === undefined || s === t) continue;
+		adj[s].set(t, (adj[s].get(t) ?? 0) + weight);
+		adj[t].set(s, (adj[t].get(s) ?? 0) + weight);
+		m += weight;
+	}
+
+	if (m === 0) return new Map(nodeIds.map((id, i) => [id, i]));
+
+	// k[i] = sum of edge weights incident to node i
+	const k: number[] = nodeIds.map((_, i) => {
+		let sum = 0;
+		for (const w of adj[i].values()) sum += w;
+		return sum;
+	});
+
+	// Each node starts in its own community
+	const comm: number[] = nodeIds.map((_, i) => i);
+	// sigma_tot[c] = sum of k[i] for all i in community c
+	const sigma_tot: number[] = [...k];
+
+	let improved = true;
+	let pass = 0;
+	while (improved && pass < 20) {
+		improved = false;
+		pass++;
+		for (let i = 0; i < n; i++) {
+			const ci = comm[i];
+
+			// k_i_ci: edges from i to other nodes already in ci
+			let k_i_ci = 0;
+			for (const [j, w] of adj[i]) {
+				if (comm[j] === ci) k_i_ci += w;
+			}
+
+			// Collect neighbour communities and edge weight from i to each
+			const neighComm = new Map<number, number>();
+			for (const [j, w] of adj[i]) {
+				const cj = comm[j];
+				if (cj !== ci) neighComm.set(cj, (neighComm.get(cj) ?? 0) + w);
+			}
+
+			// Modularity gain of removing i from ci (Blondel et al. 2008)
+			const remove_gain =
+				k_i_ci / m - ((sigma_tot[ci] - k[i]) * k[i]) / (2 * m * m);
+
+			let bestDQ = 0;
+			let bestC = ci;
+			for (const [cj, k_i_cj] of neighComm) {
+				const add_gain = k_i_cj / m - (sigma_tot[cj] * k[i]) / (2 * m * m);
+				const dq = add_gain - remove_gain;
+				if (dq > bestDQ) {
+					bestDQ = dq;
+					bestC = cj;
+				}
+			}
+
+			if (bestC !== ci) {
+				sigma_tot[ci] -= k[i];
+				sigma_tot[bestC] += k[i];
+				comm[i] = bestC;
+				improved = true;
+			}
+		}
+	}
+
+	// Remap community IDs to consecutive integers ordered by first appearance
+	const seen = new Map<number, number>();
+	let nextId = 0;
+	return new Map(
+		nodeIds.map((id, i) => {
+			const c = comm[i];
+			if (!seen.has(c)) seen.set(c, nextId++);
+			return [id, seen.get(c) ?? 0];
+		}),
+	);
+}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -147,10 +147,10 @@ function renderGraph(sparse: boolean) {
 		},
 		minZoom: 0.15,
 		maxZoom: 6,
-		wheelSensitivity: 0.3,
+		wheelSensitivity: 1.5,
 	});
 
-	cyInstance?.on("click", "node", (e) => {
+	cyInstance?.on("tap", "node", (e) => {
 		goto(`/genre/${e.target.data("genreId")}`);
 	});
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,7 +1,176 @@
 <script lang="ts">
+import { onMount } from "svelte";
+import { goto } from "$app/navigation";
+import { detectCommunities } from "$lib/louvain";
 import type { PageData } from "./$types";
 
 let { data }: { data: PageData } = $props();
+
+const SPARSE_THRESHOLD = 3;
+let showSparse = $state(false);
+let loading = $state(true);
+let graphEl: HTMLDivElement;
+
+// Module-level handles so toggle can reach them after mount
+let cyLib: ((opts: unknown) => unknown) | null = null;
+let cyInstance: {
+	destroy(): void;
+	on(
+		evt: string,
+		sel: string,
+		fn: (e: { target: { data(k: string): unknown } }) => void,
+	): void;
+} | null = null;
+
+// Precompute communities on the full dataset
+const communities = $derived(
+	detectCommunities(
+		data.vertices.map((v) => v.genre_id),
+		data.edges.map((e) => ({
+			source: e.source_genre_id,
+			target: e.target_genre_id,
+			weight: e.shared_artist_count,
+		})),
+	),
+);
+const numCommunities = $derived(Math.max(...communities.values(), 0) + 1);
+
+// Evenly-spaced HSL hues — offset by 200 to start near the accent purple
+function communityColor(commId: number): string {
+	const hue = Math.round(((commId / numCommunities) * 360 + 200) % 360);
+	return `hsl(${hue}, 62%, 56%)`;
+}
+
+// Log-scale node diameter: 18–58 px
+const maxCount = $derived(
+	Math.max(...data.vertices.map((v) => v.artist_count), 1),
+);
+function nodeSize(count: number): number {
+	return 18 + 40 * (Math.log(count + 1) / Math.log(maxCount + 1));
+}
+
+// Linear edge width: 0.5–4 px
+const maxShared = $derived(
+	Math.max(...data.edges.map((e) => e.shared_artist_count), 1),
+);
+function edgeWidth(count: number): number {
+	return 0.5 + 3.5 * (count / maxShared);
+}
+
+function renderGraph(sparse: boolean) {
+	if (!cyLib || !graphEl) return;
+	cyInstance?.destroy();
+
+	const verts = sparse
+		? data.vertices
+		: data.vertices.filter((v) => v.artist_count >= SPARSE_THRESHOLD);
+	const visibleIds = new Set(verts.map((v) => v.genre_id));
+	const filteredEdges = data.edges.filter(
+		(e) =>
+			visibleIds.has(e.source_genre_id) && visibleIds.has(e.target_genre_id),
+	);
+
+	// @ts-expect-error — dynamic import, no static type here
+	cyInstance = cyLib({
+		container: graphEl,
+		elements: {
+			nodes: verts.map((v) => ({
+				data: {
+					id: String(v.genre_id),
+					label: v.name,
+					size: nodeSize(v.artist_count),
+					color: communityColor(communities.get(v.genre_id) ?? 0),
+					genreId: v.genre_id,
+				},
+			})),
+			edges: filteredEdges.map((e) => ({
+				data: {
+					source: String(e.source_genre_id),
+					target: String(e.target_genre_id),
+					width: edgeWidth(e.shared_artist_count),
+				},
+			})),
+		},
+		style: [
+			{
+				selector: "node",
+				style: {
+					"background-color": "data(color)",
+					width: "data(size)",
+					height: "data(size)",
+					label: "data(label)",
+					"font-size": "8px",
+					"font-family": '"IBM Plex Sans", sans-serif',
+					color: "#e2e2f0",
+					"text-valign": "center",
+					"text-halign": "center",
+					"text-wrap": "wrap",
+					"text-max-width": "data(size)",
+					"min-zoomed-font-size": 7,
+					"border-width": 1,
+					"border-color": "rgba(0,0,0,0.35)",
+					"overlay-opacity": 0,
+					cursor: "pointer",
+				},
+			},
+			{
+				selector: "node:active",
+				style: { "overlay-opacity": 0.12, "overlay-color": "#fff" },
+			},
+			{
+				selector: "node:selected",
+				style: { "border-width": 2, "border-color": "#7c6af7" },
+			},
+			{
+				selector: "edge",
+				style: {
+					width: "data(width)",
+					"line-color": "rgba(96, 96, 160, 0.35)",
+					"curve-style": "haystack",
+					"overlay-opacity": 0,
+				},
+			},
+		],
+		layout: {
+			name: "cose",
+			animate: false,
+			randomize: false,
+			nodeRepulsion: () => 6000,
+			nodeOverlap: 20,
+			idealEdgeLength: () => 80,
+			edgeElasticity: () => 150,
+			gravity: 0.4,
+			numIter: 500,
+			initialTemp: 180,
+			coolingFactor: 0.99,
+			minTemp: 1,
+		},
+		minZoom: 0.15,
+		maxZoom: 6,
+		wheelSensitivity: 0.3,
+	});
+
+	cyInstance?.on("tap", "node", (e) => {
+		goto(`/genre/${e.target.data("genreId")}`);
+	});
+
+	loading = false;
+}
+
+onMount(() => {
+	import("cytoscape").then(({ default: cytoscape }) => {
+		cyLib = cytoscape as unknown as typeof cyLib;
+		renderGraph(showSparse);
+	});
+	return () => cyInstance?.destroy();
+});
+
+function toggleSparse() {
+	showSparse = !showSparse;
+	loading = true;
+	// Small delay so the spinner renders before the synchronous layout runs
+	setTimeout(() => renderGraph(showSparse), 16);
+}
 </script>
 
 <svelte:head>
@@ -15,13 +184,17 @@ let { data }: { data: PageData } = $props();
 
 <div class="toolbar card">
 	<label>
-		<input type="checkbox" />
-		<span>Show genres with fewer than 3 artists</span>
+		<input type="checkbox" checked={showSparse} onchange={toggleSparse} />
+		<span>Show genres with fewer than {SPARSE_THRESHOLD} artists</span>
 	</label>
+	<span class="stat mono muted">{data.vertices.length} genres · {data.edges.length} connections</span>
 </div>
 
-<div class="graph-container card">
-	<div class="graph-placeholder mono muted">Graph visualization coming soon</div>
+<div class="graph-wrapper card">
+	{#if loading}
+		<div class="overlay mono muted">Loading graph…</div>
+	{/if}
+	<div class="graph-container" bind:this={graphEl}></div>
 </div>
 
 <style>
@@ -49,21 +222,40 @@ let { data }: { data: PageData } = $props();
 		cursor: pointer;
 		color: var(--text-muted);
 		font-size: 13px;
+		user-select: none;
 	}
 
-	.toolbar input[type='checkbox'] {
+	.toolbar input[type="checkbox"] {
 		accent-color: var(--accent);
+		cursor: pointer;
 	}
 
-	.graph-container {
+	.stat {
+		margin-left: auto;
+		font-size: 12px;
+	}
+
+	.graph-wrapper {
+		position: relative;
 		height: 75vh;
 		min-height: 500px;
+		padding: 0;
+		overflow: hidden;
+	}
+
+	.overlay {
+		position: absolute;
+		inset: 0;
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		font-size: 13px;
+		z-index: 1;
+		background: var(--surface);
 	}
 
-	.graph-placeholder {
-		font-size: 13px;
+	.graph-container {
+		width: 100%;
+		height: 100%;
 	}
 </style>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -147,10 +147,10 @@ function renderGraph(sparse: boolean) {
 		},
 		minZoom: 0.15,
 		maxZoom: 6,
-		wheelSensitivity: 1.5,
+		wheelSensitivity: 0.3,
 	});
 
-	cyInstance?.on("tap", "node", (e) => {
+	cyInstance?.on("click", "node", (e) => {
 		goto(`/genre/${e.target.data("genreId")}`);
 	});
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -147,7 +147,7 @@ function renderGraph(sparse: boolean) {
 		},
 		minZoom: 0.15,
 		maxZoom: 6,
-		wheelSensitivity: 0.3,
+		wheelSensitivity: 1.5,
 	});
 
 	cyInstance?.on("tap", "node", (e) => {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -12,7 +12,8 @@ let loading = $state(true);
 let graphEl: HTMLDivElement;
 
 // Module-level handles so toggle can reach them after mount
-let cyLib: ((opts: unknown) => unknown) | null = null;
+let cyLib: (((opts: unknown) => unknown) & { use(ext: unknown): void }) | null =
+	null;
 let cyInstance: {
 	destroy(): void;
 	on(
@@ -88,6 +89,7 @@ function renderGraph(sparse: boolean) {
 					source: String(e.source_genre_id),
 					target: String(e.target_genre_id),
 					width: edgeWidth(e.shared_artist_count),
+					shared: e.shared_artist_count,
 				},
 			})),
 		},
@@ -132,18 +134,21 @@ function renderGraph(sparse: boolean) {
 			},
 		],
 		layout: {
-			name: "cose",
+			name: "fcose",
 			animate: false,
-			randomize: false,
-			nodeRepulsion: () => 6000,
-			nodeOverlap: 20,
-			idealEdgeLength: () => 80,
-			edgeElasticity: () => 150,
-			gravity: 0.4,
-			numIter: 500,
-			initialTemp: 180,
-			coolingFactor: 0.99,
-			minTemp: 1,
+			quality: "proof",
+			randomize: true,
+			nodeRepulsion: () => 12000,
+			idealEdgeLength: (edge: { data(k: string): unknown }) =>
+				Math.max(30, 120 / Math.sqrt((edge.data("shared") as number) || 1)),
+			edgeElasticity: (edge: { data(k: string): unknown }) =>
+				Math.min(0.9, 0.05 + ((edge.data("shared") as number) || 1) / 12),
+			gravity: 0.35,
+			gravityRange: 3.8,
+			numIter: 2500,
+			tile: true,
+			tilingPaddingVertical: 10,
+			tilingPaddingHorizontal: 10,
 		},
 		minZoom: 0.15,
 		maxZoom: 6,
@@ -158,10 +163,13 @@ function renderGraph(sparse: boolean) {
 }
 
 onMount(() => {
-	import("cytoscape").then(({ default: cytoscape }) => {
-		cyLib = cytoscape as unknown as typeof cyLib;
-		renderGraph(showSparse);
-	});
+	Promise.all([import("cytoscape"), import("cytoscape-fcose")]).then(
+		([{ default: cytoscape }, { default: fcose }]) => {
+			cytoscape.use(fcose);
+			cyLib = cytoscape as unknown as typeof cyLib;
+			renderGraph(showSparse);
+		},
+	);
 	return () => cyInstance?.destroy();
 });
 

--- a/web/src/routes/+page.ts
+++ b/web/src/routes/+page.ts
@@ -1,7 +1,8 @@
 import type { PageLoad } from "./$types";
+import type { GraphData } from "./api/graph/+server";
 
 export const load: PageLoad = async ({ fetch }) => {
 	const res = await fetch("/api/graph");
-	const data = await res.json();
+	const data: GraphData = await res.json();
 	return data;
 };

--- a/web/src/routes/+page.ts
+++ b/web/src/routes/+page.ts
@@ -3,6 +3,7 @@ import type { GraphData } from "./api/graph/+server";
 
 export const load: PageLoad = async ({ fetch }) => {
 	const res = await fetch("/api/graph");
+	if (!res.ok) throw new Error(`Failed to load graph: ${res.status}`);
 	const data: GraphData = await res.json();
 	return data;
 };

--- a/web/src/routes/api/genre/[id]/+server.ts
+++ b/web/src/routes/api/genre/[id]/+server.ts
@@ -16,10 +16,17 @@ export interface GenreTrack {
 	occurrences: number;
 }
 
+export interface ConnectedGenre {
+	genre_id: number;
+	name: string;
+	shared_artist_count: number;
+}
+
 export interface GenreDetail {
 	genre_name: string;
 	artists: GenreArtist[];
 	tracks: GenreTrack[];
+	connected_genres: ConnectedGenre[];
 }
 
 export const GET: RequestHandler = async ({ platform, params }) => {
@@ -35,7 +42,7 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 
 	const sql = neon(dbUrl);
 
-	const [genreRows, artists, tracks] = await Promise.all([
+	const [genreRows, artists, tracks, connected_genres] = await Promise.all([
 		sql`
 			SELECT name FROM genres WHERE id = ${genreId}
 		`,
@@ -49,6 +56,18 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			GROUP BY a.id, a.name, a.spotify_id
 			ORDER BY archive_count DESC
 			LIMIT 20
+		`,
+		sql`
+			SELECT g.id AS genre_id, g.name, e.shared_artist_count
+			FROM genre_graph_edges e
+			JOIN genres g ON g.id = e.target_genre_id
+			WHERE e.source_genre_id = ${genreId}
+			UNION ALL
+			SELECT g.id AS genre_id, g.name, e.shared_artist_count
+			FROM genre_graph_edges e
+			JOIN genres g ON g.id = e.source_genre_id
+			WHERE e.target_genre_id = ${genreId}
+			ORDER BY shared_artist_count DESC
 		`,
 		sql`
 			WITH song_occurrences AS (
@@ -86,5 +105,6 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 		genre_name: (genreRows[0] as { name: string }).name,
 		artists: artists as unknown as GenreArtist[],
 		tracks: tracks as unknown as GenreTrack[],
+		connected_genres: connected_genres as unknown as ConnectedGenre[],
 	} satisfies GenreDetail);
 };

--- a/web/src/routes/api/genre/[id]/+server.ts
+++ b/web/src/routes/api/genre/[id]/+server.ts
@@ -1,3 +1,4 @@
+import { neon } from "@neondatabase/serverless";
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
@@ -18,9 +19,58 @@ export interface GenreDetail {
 	tracks: GenreTrack[];
 }
 
-export const GET: RequestHandler = async ({ params: _params }) => {
-	// TODO(PR3): query artists and top tracks for genre _params.id
-	const data: GenreDetail = { genre_name: "", artists: [], tracks: [] };
+export const GET: RequestHandler = async ({ platform, params }) => {
+	const genreId = Number(params.id);
+	if (!Number.isInteger(genreId) || genreId <= 0) {
+		return new Response("Invalid genre ID", { status: 400 });
+	}
 
-	return json(data);
+	const dbUrl = platform?.env?.DATABASE_URL;
+	if (!dbUrl) {
+		return new Response("DATABASE_URL not configured", { status: 500 });
+	}
+
+	const sql = neon(dbUrl);
+
+	const [genreRows, artists, tracks] = await Promise.all([
+		sql<{ name: string }[]>`
+			SELECT name FROM genres WHERE id = ${genreId}
+		`,
+		sql<GenreArtist[]>`
+			SELECT a.name, COUNT(sa.id)::int AS archive_count
+			FROM artists a
+			JOIN link_artist_genres lag ON lag.artist_id = a.id
+			JOIN link_song_artists lsa ON lsa.artist_id = a.id
+			JOIN song_archive sa ON sa.song_id = lsa.song_id
+			WHERE lag.genre_id = ${genreId}
+			GROUP BY a.id, a.name
+			ORDER BY archive_count DESC
+			LIMIT 20
+		`,
+		sql<GenreTrack[]>`
+			SELECT
+				s.name,
+				array_agg(DISTINCT a.name ORDER BY a.name) AS artist_names,
+				COUNT(sa.id)::int AS occurrences
+			FROM songs s
+			JOIN link_song_genres lsg ON lsg.song_id = s.id
+			JOIN song_archive sa ON sa.song_id = s.id
+			JOIN link_song_artists lsa ON lsa.song_id = s.id
+			JOIN artists a ON a.id = lsa.artist_id
+			WHERE lsg.genre_id = ${genreId}
+			GROUP BY s.id, s.name
+			ORDER BY occurrences DESC
+			LIMIT 20
+		`,
+	]);
+
+	if (genreRows.length === 0) {
+		return new Response("Genre not found", { status: 404 });
+	}
+
+	return json({
+		genre_name: genreRows[0].name,
+		artists,
+		tracks,
+	} satisfies GenreDetail);
 };

--- a/web/src/routes/api/genre/[id]/+server.ts
+++ b/web/src/routes/api/genre/[id]/+server.ts
@@ -4,11 +4,13 @@ import type { RequestHandler } from "./$types";
 
 export interface GenreArtist {
 	name: string;
+	spotify_id: string;
 	archive_count: number;
 }
 
 export interface GenreTrack {
 	name: string;
+	spotify_id: string;
 	artist_names: string[];
 	occurrences: number;
 }
@@ -37,19 +39,20 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			SELECT name FROM genres WHERE id = ${genreId}
 		`,
 		sql`
-			SELECT a.name, COUNT(sa.id)::int AS archive_count
+			SELECT a.name, a.spotify_id, COUNT(sa.id)::int AS archive_count
 			FROM artists a
 			JOIN link_artist_genres lag ON lag.artist_id = a.id
 			JOIN link_song_artists lsa ON lsa.artist_id = a.id
 			JOIN song_archive sa ON sa.song_id = lsa.song_id
 			WHERE lag.genre_id = ${genreId}
-			GROUP BY a.id, a.name
+			GROUP BY a.id, a.name, a.spotify_id
 			ORDER BY archive_count DESC
 			LIMIT 20
 		`,
 		sql`
 			SELECT
 				s.name,
+				s.spotify_id,
 				array_agg(DISTINCT a.name ORDER BY a.name) AS artist_names,
 				COUNT(sa.id)::int AS occurrences
 			FROM songs s
@@ -58,7 +61,7 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			JOIN link_song_artists lsa ON lsa.song_id = s.id
 			JOIN artists a ON a.id = lsa.artist_id
 			WHERE lsg.genre_id = ${genreId}
-			GROUP BY s.id, s.name
+			GROUP BY s.id, s.name, s.spotify_id
 			ORDER BY occurrences DESC
 			LIMIT 20
 		`,

--- a/web/src/routes/api/genre/[id]/+server.ts
+++ b/web/src/routes/api/genre/[id]/+server.ts
@@ -33,10 +33,10 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 	const sql = neon(dbUrl);
 
 	const [genreRows, artists, tracks] = await Promise.all([
-		sql<{ name: string }[]>`
+		sql`
 			SELECT name FROM genres WHERE id = ${genreId}
 		`,
-		sql<GenreArtist[]>`
+		sql`
 			SELECT a.name, COUNT(sa.id)::int AS archive_count
 			FROM artists a
 			JOIN link_artist_genres lag ON lag.artist_id = a.id
@@ -47,7 +47,7 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			ORDER BY archive_count DESC
 			LIMIT 20
 		`,
-		sql<GenreTrack[]>`
+		sql`
 			SELECT
 				s.name,
 				array_agg(DISTINCT a.name ORDER BY a.name) AS artist_names,
@@ -69,8 +69,8 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 	}
 
 	return json({
-		genre_name: genreRows[0].name,
-		artists,
-		tracks,
+		genre_name: (genreRows[0] as { name: string }).name,
+		artists: artists as unknown as GenreArtist[],
+		tracks: tracks as unknown as GenreTrack[],
 	} satisfies GenreDetail);
 };

--- a/web/src/routes/api/genre/[id]/+server.ts
+++ b/web/src/routes/api/genre/[id]/+server.ts
@@ -58,18 +58,6 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			LIMIT 20
 		`,
 		sql`
-			SELECT g.id AS genre_id, g.name, e.shared_artist_count
-			FROM genre_graph_edges e
-			JOIN genres g ON g.id = e.target_genre_id
-			WHERE e.source_genre_id = ${genreId}
-			UNION ALL
-			SELECT g.id AS genre_id, g.name, e.shared_artist_count
-			FROM genre_graph_edges e
-			JOIN genres g ON g.id = e.source_genre_id
-			WHERE e.target_genre_id = ${genreId}
-			ORDER BY shared_artist_count DESC
-		`,
-		sql`
 			WITH song_occurrences AS (
 				SELECT song_id, COUNT(id)::int AS occurrences
 				FROM song_archive
@@ -94,6 +82,18 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			GROUP BY s.id, s.name, s.spotify_id, so.occurrences
 			ORDER BY occurrences DESC
 			LIMIT 20
+		`,
+		sql`
+			SELECT g.id AS genre_id, g.name, e.shared_artist_count
+			FROM genre_graph_edges e
+			JOIN genres g ON g.id = e.target_genre_id
+			WHERE e.source_genre_id = ${genreId}
+			UNION ALL
+			SELECT g.id AS genre_id, g.name, e.shared_artist_count
+			FROM genre_graph_edges e
+			JOIN genres g ON g.id = e.source_genre_id
+			WHERE e.target_genre_id = ${genreId}
+			ORDER BY shared_artist_count DESC
 		`,
 	]);
 

--- a/web/src/routes/api/genre/[id]/+server.ts
+++ b/web/src/routes/api/genre/[id]/+server.ts
@@ -12,6 +12,7 @@ export interface GenreTrack {
 	name: string;
 	spotify_id: string;
 	artist_names: string[];
+	artist_spotify_ids: string[];
 	occurrences: number;
 }
 
@@ -50,16 +51,21 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			LIMIT 20
 		`,
 		sql`
+			WITH song_artists AS (
+				SELECT DISTINCT lsa.song_id, a.name, a.spotify_id
+				FROM link_song_artists lsa
+				JOIN artists a ON a.id = lsa.artist_id
+			)
 			SELECT
 				s.name,
 				s.spotify_id,
-				array_agg(DISTINCT a.name ORDER BY a.name) AS artist_names,
-				COUNT(sa.id)::int AS occurrences
+				array_agg(sa.name ORDER BY sa.name) AS artist_names,
+				array_agg(sa.spotify_id ORDER BY sa.name) AS artist_spotify_ids,
+				COUNT(arc.id)::int AS occurrences
 			FROM songs s
 			JOIN link_song_genres lsg ON lsg.song_id = s.id
-			JOIN song_archive sa ON sa.song_id = s.id
-			JOIN link_song_artists lsa ON lsa.song_id = s.id
-			JOIN artists a ON a.id = lsa.artist_id
+			JOIN song_archive arc ON arc.song_id = s.id
+			JOIN song_artists sa ON sa.song_id = s.id
 			WHERE lsg.genre_id = ${genreId}
 			GROUP BY s.id, s.name, s.spotify_id
 			ORDER BY occurrences DESC

--- a/web/src/routes/api/genre/[id]/+server.ts
+++ b/web/src/routes/api/genre/[id]/+server.ts
@@ -1,5 +1,6 @@
 import { neon } from "@neondatabase/serverless";
 import { json } from "@sveltejs/kit";
+import { allNamed, typed } from "$lib/allNamed";
 import type { RequestHandler } from "./$types";
 
 export interface GenreArtist {
@@ -42,11 +43,11 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 
 	const sql = neon(dbUrl);
 
-	const [genreRows, artists, tracks, connected_genres] = await Promise.all([
-		sql`
+	const { genreRows, artists, tracks, connected_genres } = await allNamed({
+		genreRows: typed<{ name: string }[]>(sql`
 			SELECT name FROM genres WHERE id = ${genreId}
-		`,
-		sql`
+		`),
+		artists: typed<GenreArtist[]>(sql`
 			SELECT a.name, a.spotify_id, COUNT(sa.id)::int AS archive_count
 			FROM artists a
 			JOIN link_artist_genres lag ON lag.artist_id = a.id
@@ -56,8 +57,8 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			GROUP BY a.id, a.name, a.spotify_id
 			ORDER BY archive_count DESC
 			LIMIT 20
-		`,
-		sql`
+		`),
+		tracks: typed<GenreTrack[]>(sql`
 			WITH song_occurrences AS (
 				SELECT song_id, COUNT(id)::int AS occurrences
 				FROM song_archive
@@ -82,8 +83,8 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			GROUP BY s.id, s.name, s.spotify_id, so.occurrences
 			ORDER BY occurrences DESC
 			LIMIT 20
-		`,
-		sql`
+		`),
+		connected_genres: typed<ConnectedGenre[]>(sql`
 			SELECT g.id AS genre_id, g.name, e.shared_artist_count
 			FROM genre_graph_edges e
 			JOIN genres g ON g.id = e.target_genre_id
@@ -94,17 +95,17 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			JOIN genres g ON g.id = e.source_genre_id
 			WHERE e.target_genre_id = ${genreId}
 			ORDER BY shared_artist_count DESC
-		`,
-	]);
+		`),
+	});
 
 	if (genreRows.length === 0) {
 		return new Response("Genre not found", { status: 404 });
 	}
 
 	return json({
-		genre_name: (genreRows[0] as { name: string }).name,
-		artists: artists as unknown as GenreArtist[],
-		tracks: tracks as unknown as GenreTrack[],
-		connected_genres: connected_genres as unknown as ConnectedGenre[],
+		genre_name: genreRows[0].name,
+		artists,
+		tracks,
+		connected_genres,
 	} satisfies GenreDetail);
 };

--- a/web/src/routes/api/genre/[id]/+server.ts
+++ b/web/src/routes/api/genre/[id]/+server.ts
@@ -51,7 +51,12 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			LIMIT 20
 		`,
 		sql`
-			WITH song_artists AS (
+			WITH song_occurrences AS (
+				SELECT song_id, COUNT(id)::int AS occurrences
+				FROM song_archive
+				GROUP BY song_id
+			),
+			song_artists AS (
 				SELECT DISTINCT lsa.song_id, a.name, a.spotify_id
 				FROM link_song_artists lsa
 				JOIN artists a ON a.id = lsa.artist_id
@@ -61,13 +66,13 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 				s.spotify_id,
 				array_agg(sa.name ORDER BY sa.name) AS artist_names,
 				array_agg(sa.spotify_id ORDER BY sa.name) AS artist_spotify_ids,
-				COUNT(arc.id)::int AS occurrences
+				so.occurrences
 			FROM songs s
 			JOIN link_song_genres lsg ON lsg.song_id = s.id
-			JOIN song_archive arc ON arc.song_id = s.id
+			JOIN song_occurrences so ON so.song_id = s.id
 			JOIN song_artists sa ON sa.song_id = s.id
 			WHERE lsg.genre_id = ${genreId}
-			GROUP BY s.id, s.name, s.spotify_id
+			GROUP BY s.id, s.name, s.spotify_id, so.occurrences
 			ORDER BY occurrences DESC
 			LIMIT 20
 		`,

--- a/web/src/routes/api/graph/+server.ts
+++ b/web/src/routes/api/graph/+server.ts
@@ -1,5 +1,6 @@
 import { neon } from "@neondatabase/serverless";
 import { json } from "@sveltejs/kit";
+import { allNamed, typed } from "$lib/allNamed";
 import type { RequestHandler } from "./$types";
 
 export interface GenreVertex {
@@ -27,23 +28,19 @@ export const GET: RequestHandler = async ({ platform }) => {
 
 	const sql = neon(dbUrl);
 
-	const [vertices, edges] = await Promise.all([
-		sql`
+	const { vertices, edges } = await allNamed({
+		vertices: typed<GenreVertex[]>(sql`
 			SELECT genre_id, name, artist_count
 			FROM genre_graph_vertices
 			ORDER BY artist_count DESC
-		`,
-		sql`
+		`),
+		edges: typed<GenreEdge[]>(sql`
 			SELECT source_genre_id, target_genre_id, shared_artist_count
 			FROM genre_graph_edges
-		`,
-	]);
+		`),
+	});
 
-	return json(
-		{
-			vertices: vertices as unknown as GenreVertex[],
-			edges: edges as unknown as GenreEdge[],
-		} satisfies GraphData,
-		{ headers: { "Cache-Control": "public, max-age=21600" } },
-	);
+	return json({ vertices, edges } satisfies GraphData, {
+		headers: { "Cache-Control": "public, max-age=21600" },
+	});
 };

--- a/web/src/routes/api/graph/+server.ts
+++ b/web/src/routes/api/graph/+server.ts
@@ -28,18 +28,22 @@ export const GET: RequestHandler = async ({ platform }) => {
 	const sql = neon(dbUrl);
 
 	const [vertices, edges] = await Promise.all([
-		sql<GenreVertex[]>`
+		sql`
 			SELECT genre_id, name, artist_count
 			FROM genre_graph_vertices
 			ORDER BY artist_count DESC
 		`,
-		sql<GenreEdge[]>`
+		sql`
 			SELECT source_genre_id, target_genre_id, shared_artist_count
 			FROM genre_graph_edges
 		`,
 	]);
 
-	return json({ vertices, edges } satisfies GraphData, {
-		headers: { "Cache-Control": "public, max-age=21600" },
-	});
+	return json(
+		{
+			vertices: vertices as unknown as GenreVertex[],
+			edges: edges as unknown as GenreEdge[],
+		} satisfies GraphData,
+		{ headers: { "Cache-Control": "public, max-age=21600" } },
+	);
 };

--- a/web/src/routes/api/graph/+server.ts
+++ b/web/src/routes/api/graph/+server.ts
@@ -1,3 +1,4 @@
+import { neon } from "@neondatabase/serverless";
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
@@ -18,11 +19,27 @@ export interface GraphData {
 	edges: GenreEdge[];
 }
 
-export const GET: RequestHandler = async () => {
-	// TODO(PR3): query genre_graph_vertices and genre_graph_edges materialized views
-	const data: GraphData = { vertices: [], edges: [] };
+export const GET: RequestHandler = async ({ platform }) => {
+	const dbUrl = platform?.env?.DATABASE_URL;
+	if (!dbUrl) {
+		return new Response("DATABASE_URL not configured", { status: 500 });
+	}
 
-	return json(data, {
+	const sql = neon(dbUrl);
+
+	const [vertices, edges] = await Promise.all([
+		sql<GenreVertex[]>`
+			SELECT genre_id, name, artist_count
+			FROM genre_graph_vertices
+			ORDER BY artist_count DESC
+		`,
+		sql<GenreEdge[]>`
+			SELECT source_genre_id, target_genre_id, shared_artist_count
+			FROM genre_graph_edges
+		`,
+	]);
+
+	return json({ vertices, edges } satisfies GraphData, {
 		headers: { "Cache-Control": "public, max-age=21600" },
 	});
 };

--- a/web/src/routes/genre/[id]/+page.svelte
+++ b/web/src/routes/genre/[id]/+page.svelte
@@ -5,26 +5,75 @@ let { data }: { data: PageData } = $props();
 </script>
 
 <svelte:head>
-	<title>Vaultbot — Genre</title>
+	<title>Vaultbot — {data.genre_name || "Genre"}</title>
 </svelte:head>
 
 <div class="page-header">
 	<a href="/" class="back mono">← Back to graph</a>
-	<h1>Genre</h1>
-	<p class="muted">Top artists and tracks for this genre in the archive.</p>
+	{#if data.notFound}
+		<h1>Genre not found</h1>
+	{:else}
+		<h1>{data.genre_name}</h1>
+		<p class="muted">
+			{data.artists.length} artist{data.artists.length !== 1 ? "s" : ""} ·
+			{data.tracks.length} top track{data.tracks.length !== 1 ? "s" : ""}
+		</p>
+	{/if}
 </div>
 
-<div class="grid">
-	<section class="card">
-		<h2>Artists</h2>
-		<p class="muted placeholder mono">Artist data coming soon</p>
-	</section>
+{#if !data.notFound}
+	<div class="grid">
+		<section class="card">
+			<h2>Artists</h2>
+			{#if data.artists.length === 0}
+				<p class="empty mono muted">No artists found</p>
+			{:else}
+				<table>
+					<thead>
+						<tr>
+							<th>Artist</th>
+							<th class="right mono">Archive plays</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each data.artists as artist}
+							<tr>
+								<td>{artist.name}</td>
+								<td class="right mono">{artist.archive_count.toLocaleString()}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			{/if}
+		</section>
 
-	<section class="card">
-		<h2>Top Tracks</h2>
-		<p class="muted placeholder mono">Track data coming soon</p>
-	</section>
-</div>
+		<section class="card">
+			<h2>Top Tracks</h2>
+			{#if data.tracks.length === 0}
+				<p class="empty mono muted">No tracks found</p>
+			{:else}
+				<table>
+					<thead>
+						<tr>
+							<th>Track</th>
+							<th>Artists</th>
+							<th class="right mono">Occurrences</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each data.tracks as track}
+							<tr>
+								<td class="track-name">{track.name}</td>
+								<td class="artist-list muted">{track.artist_names.join(", ")}</td>
+								<td class="right mono">{track.occurrences.toLocaleString()}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			{/if}
+		</section>
+	</div>
+{/if}
 
 <style>
 	.page-header {
@@ -53,18 +102,75 @@ let { data }: { data: PageData } = $props();
 		display: grid;
 		grid-template-columns: 1fr 1fr;
 		gap: 1.5rem;
+		align-items: start;
 	}
 
 	.card h2 {
-		font-size: 14px;
+		font-size: 13px;
 		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-muted);
 		margin-bottom: 1rem;
 		padding-bottom: 0.75rem;
 		border-bottom: 1px solid var(--border);
 	}
 
-	.placeholder {
+	.empty {
 		font-size: 12px;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 13px;
+	}
+
+	thead th {
+		text-align: left;
+		font-size: 11px;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		padding: 0 0 0.5rem;
+		border-bottom: 1px solid var(--border);
+	}
+
+	thead th.right {
+		text-align: right;
+	}
+
+	tbody tr {
+		border-bottom: 1px solid var(--border);
+	}
+
+	tbody tr:last-child {
+		border-bottom: none;
+	}
+
+	tbody td {
+		padding: 0.5rem 0;
+		vertical-align: top;
+	}
+
+	tbody td.right {
+		text-align: right;
+		white-space: nowrap;
+	}
+
+	.track-name {
+		font-weight: 500;
+		padding-right: 0.5rem;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 180px;
+	}
+
+	.artist-list {
+		font-size: 12px;
+		padding-right: 0.5rem;
 	}
 
 	@media (max-width: 700px) {

--- a/web/src/routes/genre/[id]/+page.svelte
+++ b/web/src/routes/genre/[id]/+page.svelte
@@ -4,7 +4,7 @@ import type { PageData } from "./$types";
 let { data }: { data: PageData } = $props();
 
 function spotifyUrl(type: "artist" | "track", spotifyId: string): string {
-	return `https://open.spotify.com/${type}/${spotifyId}`;
+	return `spotify.com:${type}:${spotifyId}`;;
 }
 </script>
 

--- a/web/src/routes/genre/[id]/+page.svelte
+++ b/web/src/routes/genre/[id]/+page.svelte
@@ -82,7 +82,17 @@ function spotifyUrl(type: "artist" | "track", spotifyId: string): string {
 										class="spotify-link"
 									>{track.name}</a>
 								</td>
-								<td class="artist-list muted">{track.artist_names.join(", ")}</td>
+								<td class="artist-list muted">
+									{#each track.artist_names as name, i}
+										{#if i > 0}<span>, </span>{/if}
+										<a
+											href={spotifyUrl("artist", track.artist_spotify_ids[i])}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="spotify-link muted-link"
+										>{name}</a>
+									{/each}
+								</td>
 								<td class="right mono">{track.occurrences.toLocaleString()}</td>
 							</tr>
 						{/each}
@@ -185,6 +195,10 @@ function spotifyUrl(type: "artist" | "track", spotifyId: string): string {
 	.spotify-link:hover {
 		color: var(--accent);
 		text-decoration: none;
+	}
+
+	.muted-link {
+		color: var(--text-muted);
 	}
 
 	.track-name {

--- a/web/src/routes/genre/[id]/+page.svelte
+++ b/web/src/routes/genre/[id]/+page.svelte
@@ -20,7 +20,8 @@ function spotifyUrl(type: "artist" | "track", spotifyId: string): string {
 		<h1>{data.genre_name}</h1>
 		<p class="muted">
 			{data.artists.length} artist{data.artists.length !== 1 ? "s" : ""} ·
-			{data.tracks.length} top track{data.tracks.length !== 1 ? "s" : ""}
+			{data.tracks.length} top track{data.tracks.length !== 1 ? "s" : ""} ·
+			{data.connected_genres.length} connected genre{data.connected_genres.length !== 1 ? "s" : ""}
 		</p>
 	{/if}
 </div>
@@ -101,6 +102,20 @@ function spotifyUrl(type: "artist" | "track", spotifyId: string): string {
 			{/if}
 		</section>
 	</div>
+
+	{#if data.connected_genres.length > 0}
+		<section class="card related">
+			<h2>Related Genres</h2>
+			<div class="chips">
+				{#each data.connected_genres as genre}
+					<a href="/genre/{genre.genre_id}" class="chip">
+						<span class="chip-name">{genre.name}</span>
+						<span class="chip-count mono">{genre.shared_artist_count}</span>
+					</a>
+				{/each}
+			</div>
+		</section>
+	{/if}
 {/if}
 
 <style>
@@ -212,6 +227,46 @@ function spotifyUrl(type: "artist" | "track", spotifyId: string): string {
 	.artist-list {
 		font-size: 12px;
 		padding-right: 0.5rem;
+	}
+
+	.related {
+		margin-top: 1.5rem;
+	}
+
+	.chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.3rem 0.65rem;
+		background: var(--surface-2);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		font-size: 12px;
+		color: var(--text);
+		transition: border-color 0.15s, color 0.15s;
+		text-decoration: none;
+	}
+
+	.chip:hover {
+		border-color: var(--accent);
+		color: var(--accent);
+		text-decoration: none;
+	}
+
+	.chip-count {
+		font-size: 11px;
+		color: var(--text-muted);
+		transition: color 0.15s;
+	}
+
+	.chip:hover .chip-count {
+		color: var(--accent);
 	}
 
 	@media (max-width: 700px) {

--- a/web/src/routes/genre/[id]/+page.svelte
+++ b/web/src/routes/genre/[id]/+page.svelte
@@ -4,7 +4,7 @@ import type { PageData } from "./$types";
 let { data }: { data: PageData } = $props();
 
 function spotifyUrl(type: "artist" | "track", spotifyId: string): string {
-	return `spotify.com:${type}:${spotifyId}`;;
+	return `spotify:${type}:${spotifyId}`;
 }
 </script>
 

--- a/web/src/routes/genre/[id]/+page.svelte
+++ b/web/src/routes/genre/[id]/+page.svelte
@@ -2,6 +2,10 @@
 import type { PageData } from "./$types";
 
 let { data }: { data: PageData } = $props();
+
+function spotifyUrl(type: "artist" | "track", spotifyId: string): string {
+	return `https://open.spotify.com/${type}/${spotifyId}`;
+}
 </script>
 
 <svelte:head>
@@ -38,7 +42,14 @@ let { data }: { data: PageData } = $props();
 					<tbody>
 						{#each data.artists as artist}
 							<tr>
-								<td>{artist.name}</td>
+								<td>
+									<a
+										href={spotifyUrl("artist", artist.spotify_id)}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="spotify-link"
+									>{artist.name}</a>
+								</td>
 								<td class="right mono">{artist.archive_count.toLocaleString()}</td>
 							</tr>
 						{/each}
@@ -63,7 +74,14 @@ let { data }: { data: PageData } = $props();
 					<tbody>
 						{#each data.tracks as track}
 							<tr>
-								<td class="track-name">{track.name}</td>
+								<td class="track-name">
+									<a
+										href={spotifyUrl("track", track.spotify_id)}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="spotify-link"
+									>{track.name}</a>
+								</td>
 								<td class="artist-list muted">{track.artist_names.join(", ")}</td>
 								<td class="right mono">{track.occurrences.toLocaleString()}</td>
 							</tr>
@@ -159,8 +177,17 @@ let { data }: { data: PageData } = $props();
 		white-space: nowrap;
 	}
 
+	.spotify-link {
+		color: var(--text);
+		transition: color 0.15s;
+	}
+
+	.spotify-link:hover {
+		color: var(--accent);
+		text-decoration: none;
+	}
+
 	.track-name {
-		font-weight: 500;
 		padding-right: 0.5rem;
 		white-space: nowrap;
 		overflow: hidden;

--- a/web/src/routes/genre/[id]/+page.ts
+++ b/web/src/routes/genre/[id]/+page.ts
@@ -4,7 +4,13 @@ import type { PageLoad } from "./$types";
 export const load: PageLoad = async ({ fetch, params }) => {
 	const res = await fetch(`/api/genre/${params.id}`);
 	if (res.status === 404) {
-		return { notFound: true, genre_name: "", artists: [], tracks: [] };
+		return {
+			notFound: true,
+			genre_name: "",
+			artists: [],
+			tracks: [],
+			connected_genres: [],
+		};
 	}
 	if (!res.ok) {
 		throw new Error(`Failed to load genre: ${res.status}`);

--- a/web/src/routes/genre/[id]/+page.ts
+++ b/web/src/routes/genre/[id]/+page.ts
@@ -1,7 +1,14 @@
+import type { GenreDetail } from "../../api/genre/[id]/+server";
 import type { PageLoad } from "./$types";
 
 export const load: PageLoad = async ({ fetch, params }) => {
 	const res = await fetch(`/api/genre/${params.id}`);
-	const data = await res.json();
-	return { ...data, genreId: params.id };
+	if (res.status === 404) {
+		return { notFound: true, genre_name: "", artists: [], tracks: [] };
+	}
+	if (!res.ok) {
+		throw new Error(`Failed to load genre: ${res.status}`);
+	}
+	const detail: GenreDetail = await res.json();
+	return { ...detail, notFound: false };
 };


### PR DESCRIPTION
## Summary

- **Genre graph** (`/`): Cytoscape.js force-directed graph of all genres, nodes sized logarithmically by `artist_count`, colored by Louvain community detection (`$lib/louvain.ts`), edges weighted by `shared_artist_count`. Zoom/pan enabled. Toggle to hide sparse genres (< 3 artists). Click a node to navigate to the genre drilldown.
- **Genre drilldown** (`/genre/[id]`): top-20 artists (archive play count) and top-20 tracks (occurrence count + artist list), all linked via `spotify:artist:id` / `spotify:track:id` URIs. Related genres shown as pill chips sorted by shared artist count, each linking to the connected genre's own page.
- **`$lib/allNamed` + `typed`**: helper pair that replaces positional `Promise.all` destructuring in API routes. `allNamed` keys query results by name so ordering is irrelevant; `typed<T>` confines the required neon boundary cast to a single documented location. Eliminates `as unknown as` at call sites and makes query/variable mismatches structurally impossible.

## Test plan

- [x] Home page loads and renders the genre graph (nodes visible, community colors applied)
- [x] Sparse genre toggle shows/hides small genres and re-renders the graph
- [x] Clicking a genre node navigates to `/genre/[id]`
- [x] Genre drilldown shows correct genre name, artist list, and top tracks
- [x] Artist names in both the Artists table and the Top Tracks > Artists column are clickable Spotify URIs
- [x] Track names are clickable Spotify URIs
- [x] Related genres pill row appears and each chip navigates to the correct genre
- [x] Refreshing a genre page works (no SSR 500)
- [x] `npm run check` passes with 0 errors, 0 warnings
- [x] `npm run biome` passes clean

https://claude.ai/code/session_01E4z7e4sUKwaZr6ArsrxQ4r