### PR TITLE
Set 2-day expiration on new Neon devcontainer branches

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
       "version": "1.26",
-      "golangcilintversion": "v2.11.0"
+      "golangcilintversion": "2.11.0"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "24"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
   "image": "mcr.microsoft.com/devcontainers/base:bookworm",
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.26"
+      "version": "1.26",
+      "golangcilintversion": "v2.11.0"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "24"

--- a/.devcontainer/scripts/neon-branch-setup.sh
+++ b/.devcontainer/scripts/neon-branch-setup.sh
@@ -23,16 +23,13 @@ if ! CONN_URI=$(neonctl connection-string \
   --branch "${NEON_BRANCH_NAME}" 2>/dev/null); then
 
   echo "Branch not found — creating '${NEON_BRANCH_NAME}'..."
-  neonctl branch create \
+  BRANCH_ID=$(neonctl branch create \
     --project-id "${NEON_PROJECT_ID}" \
-    --name "${NEON_BRANCH_NAME}"
+    --name "${NEON_BRANCH_NAME}" \
+    --output json | jq -r '.branch.id')
 
-  # Set 2-day expiration via the Neon REST API (neonctl has no --expires-at flag).
+  # Set 2-day expiration on this branch via the Neon REST API (neonctl has no --expires-at flag).
   EXPIRES_AT=$(date -u -d "+2 days" "+%Y-%m-%dT%H:%M:%SZ")
-  BRANCH_ID=$(curl -sf \
-    "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches" \
-    -H "Authorization: Bearer ${NEON_API_KEY}" \
-    | jq -r ".branches[] | select(.name == \"${NEON_BRANCH_NAME}\") | .id")
   curl -sf -X PATCH \
     "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches/${BRANCH_ID}" \
     -H "Authorization: Bearer ${NEON_API_KEY}" \

--- a/.devcontainer/scripts/neon-branch-setup.sh
+++ b/.devcontainer/scripts/neon-branch-setup.sh
@@ -27,6 +27,19 @@ if ! CONN_URI=$(neonctl connection-string \
     --project-id "${NEON_PROJECT_ID}" \
     --name "${NEON_BRANCH_NAME}"
 
+  # Set 2-day expiration via the Neon REST API (neonctl has no --expires-at flag).
+  EXPIRES_AT=$(date -u -d "+2 days" "+%Y-%m-%dT%H:%M:%SZ")
+  BRANCH_ID=$(curl -sf \
+    "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches" \
+    -H "Authorization: Bearer ${NEON_API_KEY}" \
+    | jq -r ".branches[] | select(.name == \"${NEON_BRANCH_NAME}\") | .id")
+  curl -sf -X PATCH \
+    "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches/${BRANCH_ID}" \
+    -H "Authorization: Bearer ${NEON_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "{\"branch\":{\"expires_at\":\"${EXPIRES_AT}\"}}" > /dev/null
+  echo "Branch expiration set to ${EXPIRES_AT} (2 days from now)."
+
   CONN_URI=$(neonctl connection-string \
     --project-id "${NEON_PROJECT_ID}" \
     --branch "${NEON_BRANCH_NAME}")


### PR DESCRIPTION
neonctl has no --expires-at flag, so after creating the branch we list
all project branches via the Neon REST API to retrieve the new branch ID,
then PATCH it with expires_at set to 48 hours from creation time.

https://claude.ai/code/session_016tcEz72ioJecHETc7hwU4D