### PR TITLE
chore: add dependabot groups for batched dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,51 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      jackc-postgres:
+        patterns:
+          - "github.com/jackc/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:
       interval: "weekly"
+    groups:
+      svelte:
+        patterns:
+          - "svelte"
+          - "svelte-*"
+          - "@sveltejs/*"
+      vite:
+        patterns:
+          - "vite"
+          - "vitest"
+      graphology:
+        patterns:
+          - "graphology"
+          - "graphology-*"
+          - "@sigma/*"
+          - "sigma"
+      chartjs:
+        patterns:
+          - "chart.js"
+          - "chartjs-*"
+      typescript-types:
+        patterns:
+          - "typescript"
+          - "@types/*"
+      cloudflare:
+        patterns:
+          - "@cloudflare/*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "actions/*"


### PR DESCRIPTION
- Groups npm deps into logical families (svelte, vite, graphology, chartjs, typescript-types, cloudflare) so related packages update together in a single PR
- Groups gomod deps by `jackc/*` (Postgres driver stack) and `golang.org/x/*`
- Groups `actions/*` GitHub Actions into a single PR
