### PR TITLE
Add Spotify playlist links to homepage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,17 @@ jobs:
         run: echo "${{ secrets.CF_PAGES_DATABASE_URL }}" | npx wrangler pages secret put
           DATABASE_URL --project-name=vaultbot
 
+      - name: Set playlist ID secrets on Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          echo "${{ secrets.SPOTIFY_PLAYLIST_ID }}" | npx wrangler pages secret put SPOTIFY_PLAYLIST_ID --project-name=vaultbot
+          echo "${{ secrets.GENRE_SPOTIFY_PLAYLIST_ID }}" | npx wrangler pages secret put GENRE_SPOTIFY_PLAYLIST_ID --project-name=vaultbot
+          echo "${{ secrets.HIGH_SCORES_SPOTIFY_PLAYLIST_ID }}" | npx wrangler pages secret put HIGH_SCORES_SPOTIFY_PLAYLIST_ID --project-name=vaultbot
+          echo "${{ secrets.THROWBACK_SPOTIFY_PLAYLIST_ID }}" | npx wrangler pages secret put THROWBACK_SPOTIFY_PLAYLIST_ID --project-name=vaultbot
+          echo "${{ secrets.VARIETY_SPOTIFY_PLAYLIST_ID }}" | npx wrangler pages secret put VARIETY_SPOTIFY_PLAYLIST_ID --project-name=vaultbot
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4
         with:

--- a/web/.dev.vars.example
+++ b/web/.dev.vars.example
@@ -1,3 +1,8 @@
 # Copy to .dev.vars for local development with `wrangler pages dev`
 # .dev.vars is gitignored
 DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
+SPOTIFY_PLAYLIST_ID=
+GENRE_SPOTIFY_PLAYLIST_ID=
+HIGH_SCORES_SPOTIFY_PLAYLIST_ID=
+THROWBACK_SPOTIFY_PLAYLIST_ID=
+VARIETY_SPOTIFY_PLAYLIST_ID=

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5412,7 +5412,6 @@
 				"tinyexec": "^1.0.2",
 				"tinyglobby": "^0.2.15",
 				"tinyrainbow": "^3.1.0",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
 				"why-is-node-running": "^2.3.0"
 			}
 		},

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -5,6 +5,11 @@ declare global {
 		interface Platform {
 			env: {
 				DATABASE_URL: string;
+				SPOTIFY_PLAYLIST_ID: string;
+				GENRE_SPOTIFY_PLAYLIST_ID: string;
+				HIGH_SCORES_SPOTIFY_PLAYLIST_ID: string;
+				THROWBACK_SPOTIFY_PLAYLIST_ID: string;
+				VARIETY_SPOTIFY_PLAYLIST_ID: string;
 			};
 			context: {
 				waitUntil(promise: Promise<unknown>): void;

--- a/web/src/lib/SpotifyLinkPill.svelte
+++ b/web/src/lib/SpotifyLinkPill.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+import { spotifyUrl } from "$lib/spotify";
+
+let {
+	type,
+	id,
+	label,
+}: {
+	type: "artist" | "track" | "playlist";
+	id: string;
+	label: string;
+} = $props();
+</script>
+
+<a
+	class="spotify-pill mono"
+	href={spotifyUrl(type, id)}
+	target="_blank"
+	rel="noopener noreferrer"
+>
+	{label}
+	<span class="arrow" aria-hidden="true">↗</span>
+</a>
+
+<style>
+	.spotify-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 6px 14px;
+		font-size: 13px;
+		color: var(--text);
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		transition:
+			border-color 0.15s,
+			color 0.15s;
+		white-space: nowrap;
+	}
+
+	.spotify-pill:hover {
+		color: var(--accent);
+		border-color: var(--accent);
+		text-decoration: none;
+	}
+
+	.arrow {
+		font-size: 11px;
+	}
+</style>

--- a/web/src/lib/SpotifyLinkPill.svelte
+++ b/web/src/lib/SpotifyLinkPill.svelte
@@ -26,11 +26,10 @@ let {
 	.spotify-pill {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.4rem;
-		padding: 6px 14px;
-		font-size: 13px;
-		color: var(--text);
-		background: var(--surface);
+		gap: 0.3rem;
+		padding: 0.2rem 0.6rem;
+		font-size: 11px;
+		color: var(--text-muted);
 		border: 1px solid var(--border);
 		border-radius: 999px;
 		transition:
@@ -46,6 +45,6 @@ let {
 	}
 
 	.arrow {
-		font-size: 11px;
+		font-size: 10px;
 	}
 </style>

--- a/web/src/lib/StatsCharts.svelte
+++ b/web/src/lib/StatsCharts.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { ChartComponent } from "chart.js";
 import type { TreemapDataPoint } from "chartjs-chart-treemap";
 import { onMount } from "svelte";
 import { fmtMonth, treemapColor } from "$lib/stats";
@@ -51,6 +52,10 @@ onMount(() => {
 			} = chartjs;
 			const { TreemapController, TreemapElement } = treemap;
 
+			// FIXME: chartjs-chart-treemap's own .d.ts omits the static `id`
+			// (and other ChartComponent members) it assigns to TreemapController
+			// at runtime, and its package.json `exports` blocks augmenting the
+			// declaration file directly. Drop this cast once upstream fixes it.
 			Chart.register(
 				CategoryScale,
 				LinearScale,
@@ -61,8 +66,8 @@ onMount(() => {
 				BarController,
 				Filler,
 				Tooltip,
-				TreemapController,
-				TreemapElement,
+				TreemapController as unknown as ChartComponent,
+				TreemapElement as unknown as ChartComponent,
 			);
 
 			Chart.defaults.color = "#6060a0";

--- a/web/src/lib/spotify.test.ts
+++ b/web/src/lib/spotify.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { spotifyUrl } from "./spotify";
+
+describe("spotifyUrl", () => {
+	it("builds a deeplink for an artist", () => {
+		expect(spotifyUrl("artist", "123")).toBe("spotify:artist:123");
+	});
+
+	it("builds a deeplink for a track", () => {
+		expect(spotifyUrl("track", "456")).toBe("spotify:track:456");
+	});
+
+	it("builds a deeplink for a playlist", () => {
+		expect(spotifyUrl("playlist", "789")).toBe("spotify:playlist:789");
+	});
+});

--- a/web/src/lib/spotify.ts
+++ b/web/src/lib/spotify.ts
@@ -1,3 +1,6 @@
-export function spotifyUrl(type: "artist" | "track", id: string): string {
+export function spotifyUrl(
+	type: "artist" | "track" | "playlist",
+	id: string,
+): string {
 	return `spotify:${type}:${id}`;
 }

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
 import { goto } from "$app/navigation";
 import StatsCharts from "$lib/StatsCharts.svelte";
+import { spotifyUrl } from "$lib/spotify";
 import type { PageData } from "./$types";
 
 let { data }: { data: PageData } = $props();
+
+const playlistLinks = $derived([
+	{ label: "Dynamic", id: data.playlists.dynamic },
+	{ label: "Genre Rotation", id: data.playlists.genre },
+	{ label: "Highscores", id: data.playlists.highscores },
+	{ label: "Throwback", id: data.playlists.throwback },
+	{ label: "Variety", id: data.playlists.variety },
+]);
 
 function fmt(n: number): string {
 	return n.toLocaleString("en-US");
@@ -53,6 +62,17 @@ function fmtDate(iso: string): string {
 	</div>
 </div>
 
+<div class="playlists">
+	<span class="playlists-label mono muted">Playlists</span>
+	<div class="playlist-links">
+		{#each playlistLinks as playlist (playlist.label)}
+			<a class="playlist-pill" href={spotifyUrl("playlist", playlist.id)}>
+				{playlist.label}
+			</a>
+		{/each}
+	</div>
+</div>
+
 <StatsCharts
 	{data}
 	onGenreClick={(id) => goto(`/genres/${id}`)}
@@ -94,6 +114,45 @@ function fmtDate(iso: string): string {
 		letter-spacing: -0.03em;
 		color: var(--text);
 		line-height: 1;
+	}
+
+	.playlists {
+		display: flex;
+		align-items: center;
+		gap: 16px;
+		flex-wrap: wrap;
+		margin-bottom: 40px;
+	}
+
+	.playlists-label {
+		font-size: 11px;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
+
+	.playlist-links {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 10px;
+	}
+
+	.playlist-pill {
+		display: inline-block;
+		padding: 6px 14px;
+		font-size: 13px;
+		color: var(--text);
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		transition:
+			border-color 0.15s,
+			color 0.15s;
+	}
+
+	.playlist-pill:hover {
+		color: var(--accent);
+		border-color: var(--accent);
+		text-decoration: none;
 	}
 
 	@media (max-width: 900px) {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -38,7 +38,7 @@ function fmtDate(iso: string): string {
 </script>
 
 <svelte:head>
-	<title>Vaultbot — Stats</title>
+	<title>Vaultbot :: Stats</title>
 </svelte:head>
 
 <p class="meta mono muted">{fmtDate(data.generated_at)}</p>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { goto } from "$app/navigation";
+import SpotifyLinkPill from "$lib/SpotifyLinkPill.svelte";
 import StatsCharts from "$lib/StatsCharts.svelte";
-import { spotifyUrl } from "$lib/spotify";
 import type { PageData } from "./$types";
 
 let { data }: { data: PageData } = $props();
@@ -66,9 +66,7 @@ function fmtDate(iso: string): string {
 	<span class="playlists-label mono muted">Playlists</span>
 	<div class="playlist-links">
 		{#each playlistLinks as playlist (playlist.label)}
-			<a class="playlist-pill" href={spotifyUrl("playlist", playlist.id)}>
-				{playlist.label}
-			</a>
+			<SpotifyLinkPill type="playlist" id={playlist.id} label={playlist.label} />
 		{/each}
 	</div>
 </div>
@@ -134,25 +132,6 @@ function fmtDate(iso: string): string {
 		display: flex;
 		flex-wrap: wrap;
 		gap: 10px;
-	}
-
-	.playlist-pill {
-		display: inline-block;
-		padding: 6px 14px;
-		font-size: 13px;
-		color: var(--text);
-		background: var(--surface);
-		border: 1px solid var(--border);
-		border-radius: 999px;
-		transition:
-			border-color 0.15s,
-			color 0.15s;
-	}
-
-	.playlist-pill:hover {
-		color: var(--accent);
-		border-color: var(--accent);
-		text-decoration: none;
 	}
 
 	@media (max-width: 900px) {

--- a/web/src/routes/+page.ts
+++ b/web/src/routes/+page.ts
@@ -1,9 +1,21 @@
+import { allNamed } from "$lib/allNamed";
 import type { PageLoad } from "./$types";
+import type { PlaylistIds } from "./api/playlists/+server";
 import type { StatsData } from "./api/stats/+server";
 
 export const load: PageLoad = async ({ fetch }) => {
-	const res = await fetch("/api/stats");
-	if (!res.ok) throw new Error(`Failed to load stats: ${res.status}`);
-	const data: StatsData = await res.json();
-	return data;
+	const { stats, playlists } = await allNamed({
+		stats: (async () => {
+			const res = await fetch("/api/stats");
+			if (!res.ok) throw new Error(`Failed to load stats: ${res.status}`);
+			return (await res.json()) as StatsData;
+		})(),
+		playlists: (async () => {
+			const res = await fetch("/api/playlists");
+			if (!res.ok) throw new Error(`Failed to load playlists: ${res.status}`);
+			return (await res.json()) as PlaylistIds;
+		})(),
+	});
+
+	return { ...stats, playlists };
 };

--- a/web/src/routes/api/playlists/+server.ts
+++ b/web/src/routes/api/playlists/+server.ts
@@ -1,0 +1,31 @@
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+
+export interface PlaylistIds {
+	dynamic: string;
+	genre: string;
+	highscores: string;
+	throwback: string;
+	variety: string;
+}
+
+export const GET: RequestHandler = async ({ platform }) => {
+	const env = platform?.env;
+	if (
+		!env?.SPOTIFY_PLAYLIST_ID ||
+		!env?.GENRE_SPOTIFY_PLAYLIST_ID ||
+		!env?.HIGH_SCORES_SPOTIFY_PLAYLIST_ID ||
+		!env?.THROWBACK_SPOTIFY_PLAYLIST_ID ||
+		!env?.VARIETY_SPOTIFY_PLAYLIST_ID
+	) {
+		return new Response("Playlist IDs not configured", { status: 500 });
+	}
+
+	return json({
+		dynamic: env.SPOTIFY_PLAYLIST_ID,
+		genre: env.GENRE_SPOTIFY_PLAYLIST_ID,
+		highscores: env.HIGH_SCORES_SPOTIFY_PLAYLIST_ID,
+		throwback: env.THROWBACK_SPOTIFY_PLAYLIST_ID,
+		variety: env.VARIETY_SPOTIFY_PLAYLIST_ID,
+	} satisfies PlaylistIds);
+};

--- a/web/src/routes/artists/+page.svelte
+++ b/web/src/routes/artists/+page.svelte
@@ -44,7 +44,7 @@ const totalPages = $derived(Math.ceil(data.total / data.pageSize));
 </script>
 
 <svelte:head>
-	<title>Vaultbot — Artists</title>
+	<title>Vaultbot :: Artists</title>
 </svelte:head>
 
 <div class="page-header">

--- a/web/src/routes/artists/[id]/+page.svelte
+++ b/web/src/routes/artists/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import GenreChip from "$lib/GenreChip.svelte";
+import SpotifyLinkPill from "$lib/SpotifyLinkPill.svelte";
 import { spotifyUrl } from "$lib/spotify";
 import type { PageData } from "./$types";
 
@@ -17,12 +18,7 @@ let { data }: { data: PageData } = $props();
 	{:else}
 		<div class="title-row">
 			<h1>{data.artist_name}</h1>
-			<a
-				href={spotifyUrl("artist", data.spotify_id)}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="spotify-btn mono"
-			>Open in Spotify ↗</a>
+			<SpotifyLinkPill type="artist" id={data.spotify_id} label="Open in Spotify" />
 		</div>
 	{/if}
 </div>
@@ -110,23 +106,6 @@ let { data }: { data: PageData } = $props();
 	.page-header h1 {
 		font-size: 24px;
 		margin-bottom: 0.25rem;
-	}
-
-	.spotify-btn {
-		font-size: 11px;
-		color: var(--text-muted);
-		border: 1px solid var(--border);
-		border-radius: 999px;
-		padding: 0.2rem 0.6rem;
-		text-decoration: none;
-		transition: color 0.15s, border-color 0.15s;
-		white-space: nowrap;
-	}
-
-	.spotify-btn:hover {
-		color: var(--accent);
-		border-color: var(--accent);
-		text-decoration: none;
 	}
 
 	.genres-section {

--- a/web/src/routes/artists/[id]/+page.svelte
+++ b/web/src/routes/artists/[id]/+page.svelte
@@ -8,7 +8,7 @@ let { data }: { data: PageData } = $props();
 </script>
 
 <svelte:head>
-	<title>Vaultbot — {data.artist_name || "Artist"}</title>
+	<title>Vaultbot :: {data.artist_name || "Artist"}</title>
 </svelte:head>
 
 <div class="page-header">

--- a/web/src/routes/genres/[id]/+page.svelte
+++ b/web/src/routes/genres/[id]/+page.svelte
@@ -7,7 +7,7 @@ let { data }: { data: PageData } = $props();
 </script>
 
 <svelte:head>
-	<title>Vaultbot — {data.genre_name || "Genre"}</title>
+	<title>Vaultbot :: {data.genre_name || "Genre"}</title>
 </svelte:head>
 
 <div class="page-header">

--- a/web/src/routes/graph/+page.svelte
+++ b/web/src/routes/graph/+page.svelte
@@ -59,7 +59,7 @@ const graph = $derived(buildGenreGraph(visibleVertices, visibleEdges));
 </script>
 
 <svelte:head>
-	<title>Vaultbot — Genre Graph</title>
+	<title>Vaultbot :: Genre Graph</title>
 </svelte:head>
 
 <div class="page-header">


### PR DESCRIPTION
## Summary
- Adds a "Playlists" section to the homepage linking out to the Dynamic playlist and all four curated playlists (`spotify:playlist:{id}` deeplinks), per #185
- Wires the existing GitHub Actions playlist ID secrets through to Cloudflare Pages env vars via a new `/api/playlists` route
- Fixes a pre-existing `chartjs-chart-treemap` type error (missing static `id` in its own `.d.ts`) with a documented boundary cast
- Extracts a reusable `SpotifyLinkPill` component (label + trailing ↗ arrow) and reuses it for both the homepage playlist pills and the artist page's "Open in Spotify" link, replacing two near-duplicate styles

Closes #185
