### PR TITLE
Add node search to Playlist Galaxy graph

### DIFF
--- a/web/src/lib/GenreGraph.svelte
+++ b/web/src/lib/GenreGraph.svelte
@@ -21,6 +21,13 @@ type SigmaInst = {
 	kill(): void;
 	refresh(): void;
 	on(event: string, cb: (payload: Record<string, unknown>) => void): void;
+	getCamera(): {
+		animate(
+			state: Record<string, unknown>,
+			opts: Record<string, unknown>,
+		): void;
+	};
+	getNodeDisplayData(node: string): { x: number; y: number } | undefined;
 };
 type SigmaLib = {
 	new (
@@ -411,6 +418,23 @@ $effect(() => {
 		node && g.hasNode(node) ? new Set(g.neighbors(node)) : new Set();
 	if (!hoveredNode) sigmaInst.refresh();
 });
+
+// Pans/zooms the camera to a node, used by the galaxy page's search box to
+// jump straight to a match rather than requiring the user to hunt visually.
+// Camera x/y must be in Sigma's normalized "framed graph" space ([0,1] range
+// after Sigma fits the graph's bounding box), NOT the raw graphology x/y
+// attributes FA2 assigns (which are in arbitrary graph-layout units) —
+// animating the camera to raw coordinates points it at empty space and
+// leaves the canvas blank. getNodeDisplayData() returns the node's position
+// already converted to that normalized space.
+export function focusNode(nodeId: string): void {
+	if (!sigmaInst) return;
+	const data = sigmaInst.getNodeDisplayData(nodeId);
+	if (!data) return;
+	sigmaInst
+		.getCamera()
+		.animate({ x: data.x, y: data.y, ratio: 0.15 }, { duration: 500 });
+}
 </script>
 
 <div class="graph-wrapper card">

--- a/web/src/lib/graph.test.ts
+++ b/web/src/lib/graph.test.ts
@@ -8,6 +8,8 @@ import {
 	isolatedNodePosition,
 	nodeSize,
 	parseNodeParam,
+	type SearchableNode,
+	searchNodes,
 } from "./graph";
 
 describe("nodeSize", () => {
@@ -212,6 +214,60 @@ describe("assignCommunityColors", () => {
 		const ids = Array.from({ length: 12 }, (_, i) => i);
 		const result = assignCommunityColors(ids, COMMUNITY_PALETTE);
 		expect(new Set(result.values()).size).toBe(12);
+	});
+});
+
+describe("searchNodes", () => {
+	const nodes: SearchableNode[] = [
+		{ id: 1, kind: "genre", name: "Pop" },
+		{ id: 2, kind: "genre", name: "Pop Rock" },
+		{ id: 3, kind: "artist", name: "Poppy" },
+		{ id: 4, kind: "artist", name: "K-Pop Stars" },
+		{ id: 5, kind: "genre", name: "Jazz" },
+	];
+
+	it("returns an empty array for an empty query", () => {
+		expect(searchNodes("", nodes)).toEqual([]);
+	});
+
+	it("returns an empty array for a whitespace-only query", () => {
+		expect(searchNodes("   ", nodes)).toEqual([]);
+	});
+
+	it("returns an empty array when nothing matches", () => {
+		expect(searchNodes("xyz", nodes)).toEqual([]);
+	});
+
+	it("matches case-insensitively", () => {
+		expect(searchNodes("JAZZ", nodes).map((n) => n.name)).toEqual(["Jazz"]);
+	});
+
+	it("ranks names that start with the query above names that only contain it", () => {
+		const results = searchNodes("pop", nodes);
+		// "Pop" and "Poppy" start with "pop"; "Pop Rock" also starts with it;
+		// "K-Pop Stars" only contains it, so it must sort last.
+		expect(results[results.length - 1].name).toBe("K-Pop Stars");
+	});
+
+	it("breaks ties among startsWith matches by shorter name first", () => {
+		const results = searchNodes("pop", nodes);
+		const startsWithNames = results
+			.filter((n) => n.name.toLowerCase().startsWith("pop"))
+			.map((n) => n.name);
+		expect(startsWithNames).toEqual(["Pop", "Poppy", "Pop Rock"]);
+	});
+
+	it("respects the limit parameter", () => {
+		expect(searchNodes("pop", nodes, 1).length).toBe(1);
+	});
+
+	it("defaults the limit to 8", () => {
+		const many: SearchableNode[] = Array.from({ length: 10 }, (_, i) => ({
+			id: i,
+			kind: "genre",
+			name: `Test ${i}`,
+		}));
+		expect(searchNodes("test", many).length).toBe(8);
 	});
 });
 

--- a/web/src/lib/graph.ts
+++ b/web/src/lib/graph.ts
@@ -98,6 +98,42 @@ export interface SelectedNode {
 	id: number;
 }
 
+export interface SearchableNode {
+	id: number;
+	kind: "genre" | "artist";
+	name: string;
+}
+
+/**
+ * Ranks nodes by name match against `query`: names that start with the query
+ * rank above names that merely contain it, then shorter names, then
+ * alphabetical. Purely client-side — the caller already has the full node
+ * list loaded to build the graph, so this just filters/sorts it.
+ */
+export function searchNodes(
+	query: string,
+	nodes: SearchableNode[],
+	limit = 8,
+): SearchableNode[] {
+	const q = query.trim().toLowerCase();
+	if (!q) return [];
+
+	const matches: SearchableNode[] = [];
+	for (const node of nodes) {
+		if (node.name.toLowerCase().includes(q)) matches.push(node);
+	}
+
+	matches.sort((a, b) => {
+		const aStarts = a.name.toLowerCase().startsWith(q) ? 0 : 1;
+		const bStarts = b.name.toLowerCase().startsWith(q) ? 0 : 1;
+		if (aStarts !== bStarts) return aStarts - bStarts;
+		if (a.name.length !== b.name.length) return a.name.length - b.name.length;
+		return a.name.localeCompare(b.name);
+	});
+
+	return matches.slice(0, limit);
+}
+
 // Parses the `?node=g:14` / `?node=a:7` deep-link query param used by the
 // graph page's detail drawer. Returns null for anything malformed so callers
 // never need to special-case a bad/stale link.

--- a/web/src/routes/galaxy/+page.svelte
+++ b/web/src/routes/galaxy/+page.svelte
@@ -5,7 +5,8 @@ import { page } from "$app/state";
 import { untrack } from "svelte";
 import GenreGraph from "$lib/GenreGraph.svelte";
 import GraphDetailDrawer from "$lib/GraphDetailDrawer.svelte";
-import type { SelectedNode } from "$lib/graph";
+import type { SearchableNode, SelectedNode } from "$lib/graph";
+import { searchNodes } from "$lib/graph";
 import { buildMixedGraph } from "$lib/mixed-graph";
 import type { GraphData } from "../api/graph/+server";
 import type { PageData } from "./$types";
@@ -23,6 +24,13 @@ let showDynamic = $state(
 );
 let dynamicData = $state<GraphData | null>(null);
 let loadingDynamic = $state(false);
+
+let genreGraphInst = $state<{ focusNode: (nodeId: string) => void } | null>(
+	null,
+);
+let searchQuery = $state("");
+let activeIndex = $state(-1);
+let searchWrapperEl: HTMLDivElement | undefined;
 
 // Local state, not derived from the URL: `pushState` (shallow routing) never
 // updates `page.url` — only `page.state` — so re-deriving selection from
@@ -94,6 +102,61 @@ const selectedGraphNodeId = $derived(
 		: null,
 );
 
+const searchableNodes = $derived<SearchableNode[]>([
+	...activeData.genreVertices.map((v) => ({
+		id: v.genre_id,
+		kind: "genre" as const,
+		name: v.name,
+	})),
+	...visibleArtistVertices.map((v) => ({
+		id: v.artist_id,
+		kind: "artist" as const,
+		name: v.name,
+	})),
+]);
+
+const searchResults = $derived(searchNodes(searchQuery, searchableNodes));
+const searchOpen = $derived(searchQuery.trim().length > 0);
+
+function selectSearchResult(node: SearchableNode): void {
+	selectNode(node.id, node.kind);
+	const prefix = node.kind === "genre" ? "g" : "a";
+	genreGraphInst?.focusNode(`${prefix}:${node.id}`);
+	searchQuery = "";
+	activeIndex = -1;
+}
+
+function handleSearchKeydown(e: KeyboardEvent): void {
+	if (searchResults.length === 0) {
+		if (e.key === "Escape") {
+			searchQuery = "";
+			activeIndex = -1;
+		}
+		return;
+	}
+	if (e.key === "ArrowDown") {
+		e.preventDefault();
+		activeIndex = (activeIndex + 1) % searchResults.length;
+	} else if (e.key === "ArrowUp") {
+		e.preventDefault();
+		activeIndex =
+			(activeIndex - 1 + searchResults.length) % searchResults.length;
+	} else if (e.key === "Enter") {
+		e.preventDefault();
+		selectSearchResult(searchResults[Math.max(activeIndex, 0)]);
+	} else if (e.key === "Escape") {
+		searchQuery = "";
+		activeIndex = -1;
+	}
+}
+
+function handleWindowClick(e: MouseEvent): void {
+	if (searchWrapperEl && !searchWrapperEl.contains(e.target as Node)) {
+		searchQuery = "";
+		activeIndex = -1;
+	}
+}
+
 function selectNode(id: number, kind: "genre" | "artist"): void {
 	// pushState's second argument must be structured-cloneable by the History
 	// API, so a plain object literal is passed here rather than `selectedNode`
@@ -113,6 +176,8 @@ function clearSelection(): void {
 <svelte:head>
 	<title>Vaultbot :: Playlist Galaxy</title>
 </svelte:head>
+
+<svelte:window onclick={handleWindowClick} />
 
 <div class="page-header">
 	<h1>Playlist Galaxy</h1>
@@ -135,6 +200,37 @@ function clearSelection(): void {
 		/>
 		<span>Current playlist only <span class="pill">≤ 2 weeks</span></span>
 	</label>
+	<div class="search-wrapper" bind:this={searchWrapperEl}>
+		<input
+			type="text"
+			class="search-input"
+			placeholder="Find a genre or artist…"
+			bind:value={searchQuery}
+			onkeydown={handleSearchKeydown}
+		/>
+		{#if searchOpen}
+			<div class="search-dropdown card">
+				{#if searchResults.length === 0}
+					<div class="search-empty muted">No matches</div>
+				{:else}
+					{#each searchResults as result, i (`${result.kind}:${result.id}`)}
+						<button
+							type="button"
+							class="search-result"
+							class:active={i === activeIndex}
+							onclick={() => selectSearchResult(result)}
+							onmouseenter={() => (activeIndex = i)}
+						>
+							<span class="search-glyph"
+								>{result.kind === "artist" ? "🎨" : "🎵"}</span
+							>
+							<span class="search-name">{result.name}</span>
+						</button>
+					{/each}
+				{/if}
+			</div>
+		{/if}
+	</div>
 	<span class="stat mono muted"
 		>{activeData.genreVertices.length} genres · {visibleArtistVertices.length} artists · {connectionCount} connections</span
 	>
@@ -145,6 +241,7 @@ function clearSelection(): void {
 {:else}
 	<div class="graph-row">
 		<GenreGraph
+			bind:this={genreGraphInst}
 			{graph}
 			selectedNode={selectedGraphNodeId}
 			onNodeTap={selectNode}
@@ -208,6 +305,71 @@ function clearSelection(): void {
 	.stat {
 		margin-left: auto;
 		font-size: 12px;
+	}
+
+	.search-wrapper {
+		position: relative;
+		width: 240px;
+	}
+
+	.search-input {
+		width: 100%;
+		background: var(--surface-2);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text);
+		font-size: 13px;
+		padding: 6px 10px;
+	}
+
+	.search-input:focus {
+		outline: none;
+		border-color: var(--accent);
+	}
+
+	.search-dropdown {
+		position: absolute;
+		top: calc(100% + 4px);
+		left: 0;
+		right: 0;
+		z-index: 10;
+		padding: 4px;
+		max-height: 280px;
+		overflow-y: auto;
+	}
+
+	.search-empty {
+		padding: 8px 10px;
+		font-size: 13px;
+	}
+
+	.search-result {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+		padding: 6px 10px;
+		border-radius: calc(var(--radius) - 4px);
+		background: transparent;
+		color: var(--text);
+		font-size: 13px;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	.search-result:hover,
+	.search-result.active {
+		background: var(--surface-2);
+	}
+
+	.search-glyph {
+		font-size: 12px;
+	}
+
+	.search-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.loading {

--- a/web/src/routes/galaxy/+page.svelte
+++ b/web/src/routes/galaxy/+page.svelte
@@ -120,8 +120,6 @@ const searchOpen = $derived(searchQuery.trim().length > 0);
 
 function selectSearchResult(node: SearchableNode): void {
 	selectNode(node.id, node.kind);
-	const prefix = node.kind === "genre" ? "g" : "a";
-	genreGraphInst?.focusNode(`${prefix}:${node.id}`);
 	searchQuery = "";
 	activeIndex = -1;
 }
@@ -165,6 +163,10 @@ function selectNode(id: number, kind: "genre" | "artist"): void {
 	selectedNode = { kind, id };
 	const prefix = kind === "genre" ? "g" : "a";
 	pushState(`?node=${prefix}:${id}`, { node: { kind, id } });
+	// Single chokepoint for every selection path (canvas click, drawer
+	// cross-link pivot, search result) so the camera always frames whatever
+	// node is currently selected, not just search-originated ones.
+	genreGraphInst?.focusNode(`${prefix}:${id}`);
 }
 
 function clearSelection(): void {


### PR DESCRIPTION
Once the standalone artists index page was removed in favor of the mixed genre/artist graph, its search-by-name affordance had no replacement. As the graph scales toward thousands of nodes, finding a specific genre or artist visually becomes impractical.

This adds a client-side search box to the Playlist Galaxy toolbar that filters the node data already loaded for the graph (no new API), ranks matches by name relevance, and pans/zooms the camera to a selected result. That camera adjustment is applied consistently across every way a node gets selected — a direct click on the canvas, a cross-link pivot inside the detail drawer, or a search result — all routed through the same selection chokepoint.

Resolves #208