### PR TITLE
feat(web): add Collaborators section to artist detail panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,18 +117,20 @@ go run ./cmd/stats                      # Generate stats JSON (stdout) — super
 │   │   │   ├── +layout.svelte  # Root layout (header, nav, footer)
 │   │   │   ├── +page.svelte    # Stats dashboard (summary cards + charts)
 │   │   │   ├── +page.ts        # Fetches /api/stats
-│   │   │   ├── graph/          # Interactive mixed genre/artist graph page
+│   │   │   ├── galaxy/         # Interactive mixed genre/artist graph page (drawer-based detail view)
 │   │   │   │   ├── +page.svelte
-│   │   │   │   └── +page.ts    # Fetches /api/graph
-│   │   │   ├── genres/[id]/    # Genre drilldown page
-│   │   │   ├── artists/[id]/   # Artist drilldown page (no index page — the graph is the entry point)
+│   │   │   │   └── +page.ts    # Fetches /api/graph; deep-links to a selected node's detail panel
 │   │   │   └── api/            # Server-side API routes (Cloudflare Pages Functions)
 │   │   │       ├── stats/      # GET /api/stats
 │   │   │       ├── graph/      # GET /api/graph (mixed genre + artist vertices/edges)
 │   │   │       ├── genres/[id]/  # GET /api/genres/:id
 │   │   │       └── artists/[id]/ # GET /api/artists/:id
 │   │   └── lib/
-│   │       ├── GenreGraph.svelte   # Sigma.js graph renderer
+│   │       ├── GenreGraph.svelte        # Sigma.js graph renderer
+│   │       ├── GraphDetailDrawer.svelte # Drawer that renders GenreDetailPanel/ArtistDetailPanel for the selected node
+│   │       ├── GenreDetailPanel.svelte  # Genre detail: artists, top tracks, related genres
+│   │       ├── ArtistDetailPanel.svelte # Artist detail: genres, songs, collaborators
+│   │       ├── GenreChip.svelte         # Generic name+count chip used by both detail panels
 │   │       ├── mixed-graph.ts      # Builds the graphology Graph (genre + artist nodes/edges) from API data
 │   │       ├── StatsCharts.svelte  # Chart.js charts component (line, bar, treemap)
 │   │       ├── allNamed.ts         # Parallel DB query helper

--- a/web/src/lib/ArtistDetailPanel.svelte
+++ b/web/src/lib/ArtistDetailPanel.svelte
@@ -73,6 +73,21 @@ let {
 	{/if}
 </section>
 
+{#if data.connected_artists.length > 0}
+	<section class="block">
+		<h3>Collaborators</h3>
+		<div class="chips">
+			{#each data.connected_artists as artist}
+				<GenreChip
+					name={artist.name}
+					count={artist.shared_song_count}
+					onClick={() => onSelectArtist(artist.artist_id)}
+				/>
+			{/each}
+		</div>
+	</section>
+{/if}
+
 <style>
 	.title-row {
 		display: flex;

--- a/web/src/routes/api/artists/[id]/+server.ts
+++ b/web/src/routes/api/artists/[id]/+server.ts
@@ -17,11 +17,18 @@ export interface ArtistGenre {
 	name: string;
 }
 
+export interface ConnectedArtist {
+	artist_id: number;
+	name: string;
+	shared_song_count: number;
+}
+
 export interface ArtistDetail {
 	artist_name: string;
 	spotify_id: string;
 	songs: ArtistSong[];
 	genres: ArtistGenre[];
+	connected_artists: ConnectedArtist[];
 }
 
 export const GET: RequestHandler = async ({ platform, params }) => {
@@ -37,7 +44,7 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 
 	const sql = neon(dbUrl);
 
-	const { artistRows, songs, genres } = await allNamed({
+	const { artistRows, songs, genres, connected_artists } = await allNamed({
 		artistRows: typed<{ name: string; spotify_id: string }[]>(sql`
 			SELECT name, spotify_id FROM artists WHERE id = ${artistId}
 		`),
@@ -75,6 +82,19 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 			WHERE lag.artist_id = ${artistId}
 			ORDER BY g.name
 		`),
+		connected_artists: typed<ConnectedArtist[]>(sql`
+			SELECT a.id AS artist_id, a.name, e.shared_song_count
+			FROM artist_graph_edges e
+			JOIN artists a ON a.id = e.target_artist_id
+			WHERE e.source_artist_id = ${artistId}
+			UNION ALL
+			SELECT a.id AS artist_id, a.name, e.shared_song_count
+			FROM artist_graph_edges e
+			JOIN artists a ON a.id = e.source_artist_id
+			WHERE e.target_artist_id = ${artistId}
+			ORDER BY shared_song_count DESC
+			LIMIT 20
+		`),
 	});
 
 	if (artistRows.length === 0) {
@@ -86,5 +106,6 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 		spotify_id: artistRows[0].spotify_id,
 		songs,
 		genres,
+		connected_artists,
 	} satisfies ArtistDetail);
 };

--- a/web/src/routes/galaxy/+page.svelte
+++ b/web/src/routes/galaxy/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import { untrack } from "svelte";
 import { browser } from "$app/environment";
 import { pushState } from "$app/navigation";
 import { page } from "$app/state";
-import { untrack } from "svelte";
 import GenreGraph from "$lib/GenreGraph.svelte";
 import GraphDetailDrawer from "$lib/GraphDetailDrawer.svelte";
 import type { SearchableNode, SelectedNode } from "$lib/graph";


### PR DESCRIPTION
- Adds a "Collaborators" section to the artist detail drawer panel, listing the top 20 artists who share songs with the selected artist (via the existing `artist_graph_edges` materialized view), mirroring the existing "Related Genres" pattern on the genre detail panel.
- Corrects CLAUDE.md's stale project-structure section, which still described removed standalone genre/artist page routes and the old `graph/` route path instead of `galaxy/`.

Closes #209
