### PR TITLE
fix(spotify): surface invalid_grant clearly and fix stale token docs

### DIFF
--- a/.devcontainer/SETUP.md
+++ b/.devcontainer/SETUP.md
@@ -57,7 +57,7 @@ Construct `SPOTIFY_TOKEN` from that response in the format `accessToken|refreshT
 echo "ACCESS_TOKEN|REFRESH_TOKEN|Bearer|$(( $(date +%s) + 3600 ))"
 ```
 
-Store the resulting string as the `SPOTIFY_TOKEN` secret. Once stored, the embedded refresh token means the access token renews automatically on every run — the secret never needs to be updated again.
+Store the resulting string as the `SPOTIFY_TOKEN` secret. The embedded refresh token means the access token renews automatically on every run — but as of the [2026-06-18 Spotify policy change](https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration), refresh tokens expire 6 months after authorization (existing apps affected from 2026-07-20). When that happens, every workflow using `SPOTIFY_TOKEN` will fail with an `invalid_grant` error — repeat this step to mint a fresh token and update the secret. Do this roughly every 6 months, or immediately after a workflow failure email points at `invalid_grant`.
 
 ---
 

--- a/internal/spotify/spotify.go
+++ b/internal/spotify/spotify.go
@@ -2,6 +2,7 @@ package spotify
 
 import (
 	"context"
+	"errors"
 	"os"
 	"sync"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/vaultbotx/vaultbot-lite/internal/utils"
 	"github.com/zmb3/spotify/v2"
 	auth "github.com/zmb3/spotify/v2/auth"
+	"golang.org/x/oauth2"
 )
 
 var instance *Client
@@ -89,6 +91,14 @@ func NewSpotifyClient(ctx context.Context) (*Client, error) {
 
 	_, err = client.CurrentUser(ctx)
 	if err != nil {
+		var retrieveErr *oauth2.RetrieveError
+		if errors.As(err, &retrieveErr) && retrieveErr.ErrorCode == "invalid_grant" {
+			log.Fatalf("Spotify refresh token is expired or revoked (invalid_grant). "+
+				"Refresh tokens now expire 6 months after authorization (see "+
+				"https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration). "+
+				"Re-run scripts/spotify-auth-code-flow to obtain a new token and update the "+
+				"SPOTIFY_TOKEN secret. Original error: %v", err)
+		}
 		log.Fatalf("Unable to validate Spotify credentials: %v", err)
 	}
 


### PR DESCRIPTION
Spotify now expires refresh tokens 6 months after authorization (existing apps affected from 2026-07-20), so the assumption that SPOTIFY_TOKEN never needs updating no longer holds. Detect invalid_grant specifically and fail with actionable re-auth instructions instead of a generic error; update SETUP.md accordingly.

Closes #199