### PR TITLE
feat(galaxy): time-filter sidebar detail panels to the active window

### DIFF
--- a/web/src/lib/ArtistDetailPanel.svelte
+++ b/web/src/lib/ArtistDetailPanel.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
 import GenreChip from "$lib/GenreChip.svelte";
+import type { TimeRange } from "$lib/graph";
+import { formatWindowRange } from "$lib/graph";
 import SpotifyLinkPill from "$lib/SpotifyLinkPill.svelte";
 import { spotifyUrl } from "$lib/spotify";
 import type { ArtistDetail } from "../routes/api/artists/[id]/+server";
 
 let {
 	data,
+	activeWindow,
 	onSelectGenre,
 	onSelectArtist,
 }: {
 	data: ArtistDetail;
+	activeWindow: TimeRange | null;
 	onSelectGenre: (id: number) => void;
 	onSelectArtist: (id: number) => void;
 } = $props();
@@ -19,6 +23,11 @@ let {
 	<h2 class="title">{data.artist_name}</h2>
 	<SpotifyLinkPill type="artist" id={data.spotify_id} label="Open in Spotify" />
 </div>
+{#if activeWindow}
+	<p class="window-note mono muted">
+		Showing {formatWindowRange(activeWindow[0], activeWindow[1])}
+	</p>
+{/if}
 
 {#if data.genres.length > 0}
 	<section class="block">
@@ -34,7 +43,11 @@ let {
 <section class="block">
 	<h3>Songs <span class="count mono muted">({data.songs.length.toLocaleString()})</span></h3>
 	{#if data.songs.length === 0}
-		<p class="empty mono muted">No songs found</p>
+		<p class="empty mono muted">
+			{activeWindow
+				? "Something went wrong, this should not have happened!"
+				: "No songs found"}
+		</p>
 	{:else}
 		<table>
 			<thead>
@@ -99,6 +112,11 @@ let {
 
 	.title {
 		font-size: 20px;
+	}
+
+	.window-note {
+		font-size: 11px;
+		margin: -0.75rem 0 1.25rem;
 	}
 
 	.block {

--- a/web/src/lib/ArtistDetailPanel.svelte
+++ b/web/src/lib/ArtistDetailPanel.svelte
@@ -44,9 +44,7 @@ let {
 	<h3>Songs <span class="count mono muted">({data.songs.length.toLocaleString()})</span></h3>
 	{#if data.songs.length === 0}
 		<p class="empty mono muted">
-			{activeWindow
-				? "Something went wrong, this should not have happened!"
-				: "No songs found"}
+			{activeWindow ? "No songs in this time period" : "No songs found"}
 		</p>
 	{:else}
 		<table>

--- a/web/src/lib/GenreDetailPanel.svelte
+++ b/web/src/lib/GenreDetailPanel.svelte
@@ -1,25 +1,38 @@
 <script lang="ts">
 import GenreChip from "$lib/GenreChip.svelte";
+import type { TimeRange } from "$lib/graph";
+import { formatWindowRange } from "$lib/graph";
 import { spotifyUrl } from "$lib/spotify";
 import type { GenreDetail } from "../routes/api/genres/[id]/+server";
 
 let {
 	data,
+	activeWindow,
 	onSelectGenre,
 	onSelectArtist,
 }: {
 	data: GenreDetail;
+	activeWindow: TimeRange | null;
 	onSelectGenre: (id: number) => void;
 	onSelectArtist: (id: number) => void;
 } = $props();
 </script>
 
 <h2 class="title">{data.genre_name}</h2>
+{#if activeWindow}
+	<p class="window-note mono muted">
+		Showing {formatWindowRange(activeWindow[0], activeWindow[1])}
+	</p>
+{/if}
 
 <section class="block">
 	<h3>Artists</h3>
 	{#if data.artists.length === 0}
-		<p class="empty mono muted">No artists found</p>
+		<p class="empty mono muted">
+			{activeWindow
+				? "Something went wrong, this should not have happened!"
+				: "No artists found"}
+		</p>
 	{:else}
 		<table>
 			<thead>
@@ -105,6 +118,11 @@ let {
 	.title {
 		font-size: 20px;
 		margin-bottom: 1.25rem;
+	}
+
+	.window-note {
+		font-size: 11px;
+		margin: -1rem 0 1.25rem;
 	}
 
 	.block {

--- a/web/src/lib/GenreDetailPanel.svelte
+++ b/web/src/lib/GenreDetailPanel.svelte
@@ -29,9 +29,7 @@ let {
 	<h3>Artists</h3>
 	{#if data.artists.length === 0}
 		<p class="empty mono muted">
-			{activeWindow
-				? "Something went wrong, this should not have happened!"
-				: "No artists found"}
+			{activeWindow ? "No artists in this time period" : "No artists found"}
 		</p>
 	{:else}
 		<table>

--- a/web/src/lib/GraphDetailDrawer.svelte
+++ b/web/src/lib/GraphDetailDrawer.svelte
@@ -2,7 +2,8 @@
 import { untrack } from "svelte";
 import ArtistDetailPanel from "$lib/ArtistDetailPanel.svelte";
 import GenreDetailPanel from "$lib/GenreDetailPanel.svelte";
-import type { SelectedNode } from "$lib/graph";
+import type { SelectedNode, TimeRange } from "$lib/graph";
+import { detailFetchUrl } from "$lib/graph";
 import type { ArtistDetail } from "../routes/api/artists/[id]/+server";
 import type { GenreDetail } from "../routes/api/genres/[id]/+server";
 
@@ -13,11 +14,13 @@ type Detail =
 let {
 	selected,
 	initialDetail,
+	activeWindow,
 	onSelect,
 	onClose,
 }: {
 	selected: SelectedNode | null;
 	initialDetail: Detail | null;
+	activeWindow: TimeRange | null;
 	onSelect: (id: number, kind: "genre" | "artist") => void;
 	onClose: () => void;
 } = $props();
@@ -30,18 +33,26 @@ let loading = $state(false);
 let error = $state(false);
 
 // `initialDetail` is only trustworthy for the very first non-null `selected`
-// value (the parent seeds both together from the same deep-linked node) — it
-// must never be reused once the user has clicked through to something else.
+// value (the parent seeds both together from the same deep-linked node), and
+// only when there's no active time window — it was always fetched server-side
+// as all-time data — it must never be reused once the user has clicked
+// through to something else, or once a window is active.
 let consumedInitial = false;
 
 $effect(() => {
 	const node = selected;
+	const window = activeWindow;
 	if (!node) {
 		detail = null;
 		return;
 	}
 
-	if (!consumedInitial && initialDetail && initialDetail.kind === node.kind) {
+	if (
+		!consumedInitial &&
+		!window &&
+		initialDetail &&
+		initialDetail.kind === node.kind
+	) {
 		consumedInitial = true;
 		detail = initialDetail;
 		return;
@@ -50,26 +61,30 @@ $effect(() => {
 
 	loading = true;
 	error = false;
-	const url =
-		node.kind === "genre"
-			? `/api/genres/${node.id}`
-			: `/api/artists/${node.id}`;
-	fetch(url)
-		.then((r) => {
-			if (!r.ok) throw new Error(`Failed to load: ${r.status}`);
-			return r.json();
-		})
-		.then((data) => {
-			detail =
-				node.kind === "genre"
-					? { kind: "genre", data }
-					: { kind: "artist", data };
-			loading = false;
-		})
-		.catch(() => {
-			error = true;
-			loading = false;
-		});
+
+	// Debounced so dragging the galaxy page's time-window slider (which fires
+	// `oninput` continuously) doesn't flood the detail endpoint with a request
+	// per tick — only the settled value triggers a fetch.
+	const timeoutId = setTimeout(() => {
+		fetch(detailFetchUrl(node, window))
+			.then((r) => {
+				if (!r.ok) throw new Error(`Failed to load: ${r.status}`);
+				return r.json();
+			})
+			.then((data) => {
+				detail =
+					node.kind === "genre"
+						? { kind: "genre", data }
+						: { kind: "artist", data };
+				loading = false;
+			})
+			.catch(() => {
+				error = true;
+				loading = false;
+			});
+	}, 250);
+
+	return () => clearTimeout(timeoutId);
 });
 </script>
 
@@ -83,12 +98,14 @@ $effect(() => {
 		{:else if detail?.kind === "genre"}
 			<GenreDetailPanel
 				data={detail.data}
+				{activeWindow}
 				onSelectGenre={(id) => onSelect(id, "genre")}
 				onSelectArtist={(id) => onSelect(id, "artist")}
 			/>
 		{:else if detail?.kind === "artist"}
 			<ArtistDetailPanel
 				data={detail.data}
+				{activeWindow}
 				onSelectGenre={(id) => onSelect(id, "genre")}
 				onSelectArtist={(id) => onSelect(id, "artist")}
 			/>

--- a/web/src/lib/graph.test.ts
+++ b/web/src/lib/graph.test.ts
@@ -3,12 +3,14 @@ import {
 	assignCommunityColors,
 	COMMUNITY_PALETTE,
 	desaturateColor,
+	detailFetchUrl,
 	edgeOpacity,
 	edgeWidth,
 	formatWindowRange,
 	isolatedNodePosition,
 	nodeSize,
 	parseNodeParam,
+	parseTimeRangeParams,
 	rangesOverlap,
 	type SearchableNode,
 	searchNodes,
@@ -334,6 +336,76 @@ describe("searchNodes", () => {
 			name: `Test ${i}`,
 		}));
 		expect(searchNodes("test", many).length).toBe(8);
+	});
+});
+
+describe("parseTimeRangeParams", () => {
+	it("returns null when both params are absent", () => {
+		expect(parseTimeRangeParams(new URLSearchParams())).toBeNull();
+	});
+
+	it("returns null when only start is present", () => {
+		expect(parseTimeRangeParams(new URLSearchParams("start=100"))).toBeNull();
+	});
+
+	it("returns null when only end is present", () => {
+		expect(parseTimeRangeParams(new URLSearchParams("end=200"))).toBeNull();
+	});
+
+	it("parses a valid start/end pair", () => {
+		expect(
+			parseTimeRangeParams(new URLSearchParams("start=100&end=200")),
+		).toEqual([100, 200]);
+	});
+
+	it("returns null when start is non-numeric", () => {
+		expect(
+			parseTimeRangeParams(new URLSearchParams("start=abc&end=200")),
+		).toBeNull();
+	});
+
+	it("returns null when end is non-numeric", () => {
+		expect(
+			parseTimeRangeParams(new URLSearchParams("start=100&end=xyz")),
+		).toBeNull();
+	});
+
+	it("returns null when start is after end", () => {
+		expect(
+			parseTimeRangeParams(new URLSearchParams("start=200&end=100")),
+		).toBeNull();
+	});
+
+	it("accepts start equal to end", () => {
+		expect(
+			parseTimeRangeParams(new URLSearchParams("start=100&end=100")),
+		).toEqual([100, 100]);
+	});
+});
+
+describe("detailFetchUrl", () => {
+	it("builds a bare genre URL when there is no active window", () => {
+		expect(detailFetchUrl({ kind: "genre", id: 14 }, null)).toBe(
+			"/api/genres/14",
+		);
+	});
+
+	it("builds a bare artist URL when there is no active window", () => {
+		expect(detailFetchUrl({ kind: "artist", id: 7 }, null)).toBe(
+			"/api/artists/7",
+		);
+	});
+
+	it("appends start/end params for a genre when a window is active", () => {
+		expect(detailFetchUrl({ kind: "genre", id: 14 }, [100, 200])).toBe(
+			"/api/genres/14?start=100&end=200",
+		);
+	});
+
+	it("appends start/end params for an artist when a window is active", () => {
+		expect(detailFetchUrl({ kind: "artist", id: 7 }, [100, 200])).toBe(
+			"/api/artists/7?start=100&end=200",
+		);
 	});
 });
 

--- a/web/src/lib/graph.test.ts
+++ b/web/src/lib/graph.test.ts
@@ -14,6 +14,7 @@ import {
 	rangesOverlap,
 	type SearchableNode,
 	searchNodes,
+	sqlBounds,
 	type TimeRange,
 } from "./graph";
 
@@ -380,6 +381,26 @@ describe("parseTimeRangeParams", () => {
 		expect(
 			parseTimeRangeParams(new URLSearchParams("start=100&end=100")),
 		).toEqual([100, 100]);
+	});
+});
+
+describe("sqlBounds", () => {
+	it("keeps start unchanged", () => {
+		expect(sqlBounds([100, 200]).start).toBe(100);
+	});
+
+	it("makes end exclusive by adding one second", () => {
+		expect(sqlBounds([100, 200]).endExclusive).toBe(201);
+	});
+
+	it("includes a whole-second boundary event that a naive <= end would miss", () => {
+		// A row floored to exactly `end` (the common case for the default,
+		// most-recent-activity-derived window) may really have occurred any
+		// time within that second, e.g. end + 0.9s — `< endExclusive` must
+		// still cover it.
+		const { endExclusive } = sqlBounds([100, 200]);
+		const rowEpochWithSubSecondFraction = 200.9;
+		expect(rowEpochWithSubSecondFraction < endExclusive).toBe(true);
 	});
 });
 

--- a/web/src/lib/graph.ts
+++ b/web/src/lib/graph.ts
@@ -185,3 +185,36 @@ export function parseNodeParam(value: string | null): SelectedNode | null {
 	if (!Number.isInteger(id) || id <= 0) return null;
 	return { kind: match[1] === "g" ? "genre" : "artist", id };
 }
+
+// Parses the `?start=&end=` epoch-second window shared by /api/genres/:id
+// and /api/artists/:id. Both params must be present and form a valid
+// [start, end] pair — anything else (missing, non-numeric, inverted) is
+// treated as "no time filter" rather than a request error, since a stale or
+// malformed link should fall back to all-time data instead of failing.
+export function parseTimeRangeParams(
+	searchParams: URLSearchParams,
+): TimeRange | null {
+	const startParam = searchParams.get("start");
+	const endParam = searchParams.get("end");
+	if (startParam === null || endParam === null) return null;
+	const start = Number(startParam);
+	const end = Number(endParam);
+	if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) {
+		return null;
+	}
+	return [start, end];
+}
+
+// Builds the detail-drawer fetch URL for a selected node, appending the
+// active time window as `start`/`end` query params when one is active.
+export function detailFetchUrl(
+	node: SelectedNode,
+	activeWindow: TimeRange | null,
+): string {
+	const base =
+		node.kind === "genre"
+			? `/api/genres/${node.id}`
+			: `/api/artists/${node.id}`;
+	if (!activeWindow) return base;
+	return `${base}?start=${activeWindow[0]}&end=${activeWindow[1]}`;
+}

--- a/web/src/lib/graph.ts
+++ b/web/src/lib/graph.ts
@@ -218,3 +218,17 @@ export function detailFetchUrl(
 	if (!activeWindow) return base;
 	return `${base}?start=${activeWindow[0]}&end=${activeWindow[1]}`;
 }
+
+// Converts an inclusive [start, end] window into the half-open bounds a SQL
+// `created_at` filter needs. `end` names a whole second, but it was derived
+// by flooring a (sub-second-precision) timestamp — see the graph_vertices/
+// edges materialized views — so the row it's meant to include usually has a
+// fractional second past it. Filtering with `created_at < endExclusive`
+// against the bare column (rather than flooring `created_at` itself before
+// comparing) keeps the comparison sargable against idx_song_archive_created_at.
+export function sqlBounds(range: TimeRange): {
+	start: number;
+	endExclusive: number;
+} {
+	return { start: range[0], endExclusive: range[1] + 1 };
+}

--- a/web/src/routes/api/artists/[id]/+server.ts
+++ b/web/src/routes/api/artists/[id]/+server.ts
@@ -45,6 +45,13 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 
 	const sql = neon(dbUrl);
 	const range = parseTimeRangeParams(url.searchParams);
+	// `range[1]` names a whole second, but the graph_vertices/edges materialized
+	// views that produced it floor a sub-second `created_at` down to that
+	// second (extract(epoch ...)::bigint), so the archive row it's meant to
+	// include is very often a fraction of a second *after* it. Comparing with
+	// `< range[1] + 1` treats it as an inclusive whole-second bound instead of
+	// silently excluding the very row a default (all-time-derived) window was
+	// built around.
 
 	const { artistRows, songs, genres, connected_artists } = await allNamed({
 		artistRows: typed<{ name: string; spotify_id: string }[]>(sql`
@@ -58,7 +65,7 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 					JOIN songs raw ON raw.id = sa.song_id
 					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
 					WHERE sa.created_at >= to_timestamp(${range[0]})
-						AND sa.created_at <= to_timestamp(${range[1]})
+						AND sa.created_at < to_timestamp(${range[1] + 1})
 					GROUP BY dsl.target_song_spotify_id
 				),
 				song_all_artists AS (
@@ -116,7 +123,7 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 				JOIN song_archive sa ON sa.song_id = lsa.song_id
 				WHERE lag.artist_id = ${artistId}
 					AND sa.created_at >= to_timestamp(${range[0]})
-					AND sa.created_at <= to_timestamp(${range[1]})
+					AND sa.created_at < to_timestamp(${range[1] + 1})
 				ORDER BY g.name
 			`)
 			: typed<ArtistGenre[]>(sql`
@@ -134,7 +141,7 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 					JOIN songs raw ON raw.id = sa.song_id
 					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
 					WHERE sa.created_at >= to_timestamp(${range[0]})
-						AND sa.created_at <= to_timestamp(${range[1]})
+						AND sa.created_at < to_timestamp(${range[1] + 1})
 				),
 				artist_pair_song_events AS (
 					SELECT

--- a/web/src/routes/api/artists/[id]/+server.ts
+++ b/web/src/routes/api/artists/[id]/+server.ts
@@ -1,6 +1,7 @@
 import { neon } from "@neondatabase/serverless";
 import { json } from "@sveltejs/kit";
 import { allNamed, typed } from "$lib/allNamed";
+import { parseTimeRangeParams } from "$lib/graph";
 import type { RequestHandler } from "./$types";
 
 export interface ArtistSong {
@@ -31,7 +32,7 @@ export interface ArtistDetail {
 	connected_artists: ConnectedArtist[];
 }
 
-export const GET: RequestHandler = async ({ platform, params }) => {
+export const GET: RequestHandler = async ({ platform, params, url }) => {
 	const artistId = Number(params.id);
 	if (!Number.isInteger(artistId) || artistId <= 0) {
 		return new Response("Invalid artist ID", { status: 400 });
@@ -43,58 +44,130 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 	}
 
 	const sql = neon(dbUrl);
+	const range = parseTimeRangeParams(url.searchParams);
 
 	const { artistRows, songs, genres, connected_artists } = await allNamed({
 		artistRows: typed<{ name: string; spotify_id: string }[]>(sql`
 			SELECT name, spotify_id FROM artists WHERE id = ${artistId}
 		`),
-		songs: typed<ArtistSong[]>(sql`
-			WITH canonical_occurrences AS (
-				SELECT dsl.target_song_spotify_id AS canonical_spotify_id, COUNT(sa.id)::int AS occurrences
-				FROM song_archive sa
-				JOIN songs raw ON raw.id = sa.song_id
-				JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
-				GROUP BY dsl.target_song_spotify_id
-			),
-			song_all_artists AS (
-				SELECT DISTINCT lsa.song_id, a.id AS artist_id, a.name, a.spotify_id
-				FROM link_song_artists lsa
-				JOIN artists a ON a.id = lsa.artist_id
-			)
-			SELECT
-				s.name,
-				s.spotify_id,
-				array_agg(saa.artist_id ORDER BY saa.name) AS artist_ids,
-				array_agg(saa.name ORDER BY saa.name) AS artist_names,
-				array_agg(saa.spotify_id ORDER BY saa.name) AS artist_spotify_ids,
-				co.occurrences
-			FROM v_songs s
-			JOIN link_song_artists lsa ON lsa.song_id = s.id AND lsa.artist_id = ${artistId}
-			JOIN canonical_occurrences co ON co.canonical_spotify_id = s.spotify_id
-			JOIN song_all_artists saa ON saa.song_id = s.id
-			GROUP BY s.id, s.name, s.spotify_id, co.occurrences
-			ORDER BY occurrences DESC
-		`),
-		genres: typed<ArtistGenre[]>(sql`
-			SELECT g.id AS genre_id, g.name
-			FROM genres g
-			JOIN link_artist_genres lag ON lag.genre_id = g.id
-			WHERE lag.artist_id = ${artistId}
-			ORDER BY g.name
-		`),
-		connected_artists: typed<ConnectedArtist[]>(sql`
-			SELECT a.id AS artist_id, a.name, e.shared_song_count
-			FROM artist_graph_edges e
-			JOIN artists a ON a.id = e.target_artist_id
-			WHERE e.source_artist_id = ${artistId}
-			UNION ALL
-			SELECT a.id AS artist_id, a.name, e.shared_song_count
-			FROM artist_graph_edges e
-			JOIN artists a ON a.id = e.source_artist_id
-			WHERE e.target_artist_id = ${artistId}
-			ORDER BY shared_song_count DESC
-			LIMIT 20
-		`),
+		songs: range
+			? typed<ArtistSong[]>(sql`
+				WITH canonical_occurrences AS (
+					SELECT dsl.target_song_spotify_id AS canonical_spotify_id, COUNT(sa.id)::int AS occurrences
+					FROM song_archive sa
+					JOIN songs raw ON raw.id = sa.song_id
+					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
+					WHERE sa.created_at >= to_timestamp(${range[0]})
+						AND sa.created_at <= to_timestamp(${range[1]})
+					GROUP BY dsl.target_song_spotify_id
+				),
+				song_all_artists AS (
+					SELECT DISTINCT lsa.song_id, a.id AS artist_id, a.name, a.spotify_id
+					FROM link_song_artists lsa
+					JOIN artists a ON a.id = lsa.artist_id
+				)
+				SELECT
+					s.name,
+					s.spotify_id,
+					array_agg(saa.artist_id ORDER BY saa.name) AS artist_ids,
+					array_agg(saa.name ORDER BY saa.name) AS artist_names,
+					array_agg(saa.spotify_id ORDER BY saa.name) AS artist_spotify_ids,
+					co.occurrences
+				FROM v_songs s
+				JOIN link_song_artists lsa ON lsa.song_id = s.id AND lsa.artist_id = ${artistId}
+				JOIN canonical_occurrences co ON co.canonical_spotify_id = s.spotify_id
+				JOIN song_all_artists saa ON saa.song_id = s.id
+				GROUP BY s.id, s.name, s.spotify_id, co.occurrences
+				ORDER BY occurrences DESC
+			`)
+			: typed<ArtistSong[]>(sql`
+				WITH canonical_occurrences AS (
+					SELECT dsl.target_song_spotify_id AS canonical_spotify_id, COUNT(sa.id)::int AS occurrences
+					FROM song_archive sa
+					JOIN songs raw ON raw.id = sa.song_id
+					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
+					GROUP BY dsl.target_song_spotify_id
+				),
+				song_all_artists AS (
+					SELECT DISTINCT lsa.song_id, a.id AS artist_id, a.name, a.spotify_id
+					FROM link_song_artists lsa
+					JOIN artists a ON a.id = lsa.artist_id
+				)
+				SELECT
+					s.name,
+					s.spotify_id,
+					array_agg(saa.artist_id ORDER BY saa.name) AS artist_ids,
+					array_agg(saa.name ORDER BY saa.name) AS artist_names,
+					array_agg(saa.spotify_id ORDER BY saa.name) AS artist_spotify_ids,
+					co.occurrences
+				FROM v_songs s
+				JOIN link_song_artists lsa ON lsa.song_id = s.id AND lsa.artist_id = ${artistId}
+				JOIN canonical_occurrences co ON co.canonical_spotify_id = s.spotify_id
+				JOIN song_all_artists saa ON saa.song_id = s.id
+				GROUP BY s.id, s.name, s.spotify_id, co.occurrences
+				ORDER BY occurrences DESC
+			`),
+		genres: range
+			? typed<ArtistGenre[]>(sql`
+				SELECT DISTINCT g.id AS genre_id, g.name
+				FROM genres g
+				JOIN link_artist_genres lag ON lag.genre_id = g.id
+				JOIN link_song_artists lsa ON lsa.artist_id = lag.artist_id
+				JOIN song_archive sa ON sa.song_id = lsa.song_id
+				WHERE lag.artist_id = ${artistId}
+					AND sa.created_at >= to_timestamp(${range[0]})
+					AND sa.created_at <= to_timestamp(${range[1]})
+				ORDER BY g.name
+			`)
+			: typed<ArtistGenre[]>(sql`
+				SELECT g.id AS genre_id, g.name
+				FROM genres g
+				JOIN link_artist_genres lag ON lag.genre_id = g.id
+				WHERE lag.artist_id = ${artistId}
+				ORDER BY g.name
+			`),
+		connected_artists: range
+			? typed<ConnectedArtist[]>(sql`
+				WITH canonical_events AS (
+					SELECT dsl.target_song_spotify_id AS canonical_spotify_id, sa.created_at
+					FROM song_archive sa
+					JOIN songs raw ON raw.id = sa.song_id
+					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
+					WHERE sa.created_at >= to_timestamp(${range[0]})
+						AND sa.created_at <= to_timestamp(${range[1]})
+				),
+				artist_pair_song_events AS (
+					SELECT
+						lsa1.artist_id AS source_artist_id,
+						lsa2.artist_id AS target_artist_id,
+						vs.id AS song_id
+					FROM link_song_artists lsa1
+					JOIN link_song_artists lsa2
+						ON lsa2.song_id = lsa1.song_id AND lsa2.artist_id != lsa1.artist_id
+					JOIN v_songs vs ON vs.id = lsa1.song_id
+					JOIN canonical_events ce ON ce.canonical_spotify_id = vs.spotify_id
+					WHERE lsa1.artist_id = ${artistId}
+				)
+				SELECT a.id AS artist_id, a.name, COUNT(DISTINCT song_id)::int AS shared_song_count
+				FROM artist_pair_song_events ape
+				JOIN artists a ON a.id = ape.target_artist_id
+				GROUP BY a.id, a.name
+				ORDER BY shared_song_count DESC
+				LIMIT 20
+			`)
+			: typed<ConnectedArtist[]>(sql`
+				SELECT a.id AS artist_id, a.name, e.shared_song_count
+				FROM artist_graph_edges e
+				JOIN artists a ON a.id = e.target_artist_id
+				WHERE e.source_artist_id = ${artistId}
+				UNION ALL
+				SELECT a.id AS artist_id, a.name, e.shared_song_count
+				FROM artist_graph_edges e
+				JOIN artists a ON a.id = e.source_artist_id
+				WHERE e.target_artist_id = ${artistId}
+				ORDER BY shared_song_count DESC
+				LIMIT 20
+			`),
 	});
 
 	if (artistRows.length === 0) {

--- a/web/src/routes/api/artists/[id]/+server.ts
+++ b/web/src/routes/api/artists/[id]/+server.ts
@@ -1,7 +1,7 @@
 import { neon } from "@neondatabase/serverless";
 import { json } from "@sveltejs/kit";
 import { allNamed, typed } from "$lib/allNamed";
-import { parseTimeRangeParams } from "$lib/graph";
+import { parseTimeRangeParams, sqlBounds } from "$lib/graph";
 import type { RequestHandler } from "./$types";
 
 export interface ArtistSong {
@@ -45,27 +45,21 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 
 	const sql = neon(dbUrl);
 	const range = parseTimeRangeParams(url.searchParams);
-	// `range[1]` names a whole second, but the graph_vertices/edges materialized
-	// views that produced it floor a sub-second `created_at` down to that
-	// second (extract(epoch ...)::bigint), so the archive row it's meant to
-	// include is very often a fraction of a second *after* it. Comparing with
-	// `< range[1] + 1` treats it as an inclusive whole-second bound instead of
-	// silently excluding the very row a default (all-time-derived) window was
-	// built around.
+	const bounds = range ? sqlBounds(range) : null;
 
 	const { artistRows, songs, genres, connected_artists } = await allNamed({
 		artistRows: typed<{ name: string; spotify_id: string }[]>(sql`
 			SELECT name, spotify_id FROM artists WHERE id = ${artistId}
 		`),
-		songs: range
+		songs: bounds
 			? typed<ArtistSong[]>(sql`
 				WITH canonical_occurrences AS (
 					SELECT dsl.target_song_spotify_id AS canonical_spotify_id, COUNT(sa.id)::int AS occurrences
 					FROM song_archive sa
 					JOIN songs raw ON raw.id = sa.song_id
 					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
-					WHERE sa.created_at >= to_timestamp(${range[0]})
-						AND sa.created_at < to_timestamp(${range[1] + 1})
+					WHERE sa.created_at >= to_timestamp(${bounds.start})
+						AND sa.created_at < to_timestamp(${bounds.endExclusive})
 					GROUP BY dsl.target_song_spotify_id
 				),
 				song_all_artists AS (
@@ -114,7 +108,7 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 				GROUP BY s.id, s.name, s.spotify_id, co.occurrences
 				ORDER BY occurrences DESC
 			`),
-		genres: range
+		genres: bounds
 			? typed<ArtistGenre[]>(sql`
 				SELECT DISTINCT g.id AS genre_id, g.name
 				FROM genres g
@@ -122,8 +116,8 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 				JOIN link_song_artists lsa ON lsa.artist_id = lag.artist_id
 				JOIN song_archive sa ON sa.song_id = lsa.song_id
 				WHERE lag.artist_id = ${artistId}
-					AND sa.created_at >= to_timestamp(${range[0]})
-					AND sa.created_at < to_timestamp(${range[1] + 1})
+					AND sa.created_at >= to_timestamp(${bounds.start})
+					AND sa.created_at < to_timestamp(${bounds.endExclusive})
 				ORDER BY g.name
 			`)
 			: typed<ArtistGenre[]>(sql`
@@ -133,15 +127,15 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 				WHERE lag.artist_id = ${artistId}
 				ORDER BY g.name
 			`),
-		connected_artists: range
+		connected_artists: bounds
 			? typed<ConnectedArtist[]>(sql`
 				WITH canonical_events AS (
 					SELECT dsl.target_song_spotify_id AS canonical_spotify_id, sa.created_at
 					FROM song_archive sa
 					JOIN songs raw ON raw.id = sa.song_id
 					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
-					WHERE sa.created_at >= to_timestamp(${range[0]})
-						AND sa.created_at < to_timestamp(${range[1] + 1})
+					WHERE sa.created_at >= to_timestamp(${bounds.start})
+						AND sa.created_at < to_timestamp(${bounds.endExclusive})
 				),
 				artist_pair_song_events AS (
 					SELECT

--- a/web/src/routes/api/genres/[id]/+server.ts
+++ b/web/src/routes/api/genres/[id]/+server.ts
@@ -1,6 +1,7 @@
 import { neon } from "@neondatabase/serverless";
 import { json } from "@sveltejs/kit";
 import { allNamed, typed } from "$lib/allNamed";
+import { parseTimeRangeParams } from "$lib/graph";
 import type { RequestHandler } from "./$types";
 
 export interface GenreArtist {
@@ -32,7 +33,7 @@ export interface GenreDetail {
 	connected_genres: ConnectedGenre[];
 }
 
-export const GET: RequestHandler = async ({ platform, params }) => {
+export const GET: RequestHandler = async ({ platform, params, url }) => {
 	const genreId = Number(params.id);
 	if (!Number.isInteger(genreId) || genreId <= 0) {
 		return new Response("Invalid genre ID", { status: 400 });
@@ -44,63 +45,140 @@ export const GET: RequestHandler = async ({ platform, params }) => {
 	}
 
 	const sql = neon(dbUrl);
+	const range = parseTimeRangeParams(url.searchParams);
 
 	const { genreRows, artists, tracks, connected_genres } = await allNamed({
 		genreRows: typed<{ name: string }[]>(sql`
 			SELECT name FROM genres WHERE id = ${genreId}
 		`),
-		artists: typed<GenreArtist[]>(sql`
-			SELECT a.id AS artist_id, a.name, a.spotify_id, COUNT(sa.id)::int AS archive_count
-			FROM artists a
-			JOIN link_artist_genres lag ON lag.artist_id = a.id
-			JOIN link_song_artists lsa ON lsa.artist_id = a.id
-			JOIN song_archive sa ON sa.song_id = lsa.song_id
-			WHERE lag.genre_id = ${genreId}
-			GROUP BY a.id, a.name, a.spotify_id
-			ORDER BY archive_count DESC
-			LIMIT 20
-		`),
-		tracks: typed<GenreTrack[]>(sql`
-			WITH canonical_occurrences AS (
-				SELECT dsl.target_song_spotify_id AS canonical_spotify_id, COUNT(sa.id)::int AS occurrences
-				FROM song_archive sa
-				JOIN songs raw ON raw.id = sa.song_id
-				JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
-				GROUP BY dsl.target_song_spotify_id
-			),
-			song_artists AS (
-				SELECT DISTINCT lsa.song_id, a.id AS artist_id, a.name, a.spotify_id
-				FROM link_song_artists lsa
-				JOIN artists a ON a.id = lsa.artist_id
-			)
-			SELECT
-				s.name,
-				s.spotify_id,
-				array_agg(sa.artist_id ORDER BY sa.name) AS artist_ids,
-				array_agg(sa.name ORDER BY sa.name) AS artist_names,
-				array_agg(sa.spotify_id ORDER BY sa.name) AS artist_spotify_ids,
-				co.occurrences
-			FROM v_songs s
-			JOIN link_song_genres lsg ON lsg.song_id = s.id
-			JOIN canonical_occurrences co ON co.canonical_spotify_id = s.spotify_id
-			JOIN song_artists sa ON sa.song_id = s.id
-			WHERE lsg.genre_id = ${genreId}
-			GROUP BY s.id, s.name, s.spotify_id, co.occurrences
-			ORDER BY occurrences DESC
-			LIMIT 20
-		`),
-		connected_genres: typed<ConnectedGenre[]>(sql`
-			SELECT g.id AS genre_id, g.name, e.shared_archive_count
-			FROM genre_graph_edges e
-			JOIN genres g ON g.id = e.target_genre_id
-			WHERE e.source_genre_id = ${genreId}
-			UNION ALL
-			SELECT g.id AS genre_id, g.name, e.shared_archive_count
-			FROM genre_graph_edges e
-			JOIN genres g ON g.id = e.source_genre_id
-			WHERE e.target_genre_id = ${genreId}
-			ORDER BY shared_archive_count DESC
-		`),
+		artists: range
+			? typed<GenreArtist[]>(sql`
+				SELECT a.id AS artist_id, a.name, a.spotify_id, COUNT(sa.id)::int AS archive_count
+				FROM artists a
+				JOIN link_artist_genres lag ON lag.artist_id = a.id
+				JOIN link_song_artists lsa ON lsa.artist_id = a.id
+				JOIN song_archive sa ON sa.song_id = lsa.song_id
+				WHERE lag.genre_id = ${genreId}
+					AND sa.created_at >= to_timestamp(${range[0]})
+					AND sa.created_at <= to_timestamp(${range[1]})
+				GROUP BY a.id, a.name, a.spotify_id
+				ORDER BY archive_count DESC
+				LIMIT 20
+			`)
+			: typed<GenreArtist[]>(sql`
+				SELECT a.id AS artist_id, a.name, a.spotify_id, COUNT(sa.id)::int AS archive_count
+				FROM artists a
+				JOIN link_artist_genres lag ON lag.artist_id = a.id
+				JOIN link_song_artists lsa ON lsa.artist_id = a.id
+				JOIN song_archive sa ON sa.song_id = lsa.song_id
+				WHERE lag.genre_id = ${genreId}
+				GROUP BY a.id, a.name, a.spotify_id
+				ORDER BY archive_count DESC
+				LIMIT 20
+			`),
+		tracks: range
+			? typed<GenreTrack[]>(sql`
+				WITH canonical_occurrences AS (
+					SELECT dsl.target_song_spotify_id AS canonical_spotify_id, COUNT(sa.id)::int AS occurrences
+					FROM song_archive sa
+					JOIN songs raw ON raw.id = sa.song_id
+					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
+					WHERE sa.created_at >= to_timestamp(${range[0]})
+						AND sa.created_at <= to_timestamp(${range[1]})
+					GROUP BY dsl.target_song_spotify_id
+				),
+				song_artists AS (
+					SELECT DISTINCT lsa.song_id, a.id AS artist_id, a.name, a.spotify_id
+					FROM link_song_artists lsa
+					JOIN artists a ON a.id = lsa.artist_id
+				)
+				SELECT
+					s.name,
+					s.spotify_id,
+					array_agg(sa.artist_id ORDER BY sa.name) AS artist_ids,
+					array_agg(sa.name ORDER BY sa.name) AS artist_names,
+					array_agg(sa.spotify_id ORDER BY sa.name) AS artist_spotify_ids,
+					co.occurrences
+				FROM v_songs s
+				JOIN link_song_genres lsg ON lsg.song_id = s.id
+				JOIN canonical_occurrences co ON co.canonical_spotify_id = s.spotify_id
+				JOIN song_artists sa ON sa.song_id = s.id
+				WHERE lsg.genre_id = ${genreId}
+				GROUP BY s.id, s.name, s.spotify_id, co.occurrences
+				ORDER BY occurrences DESC
+				LIMIT 20
+			`)
+			: typed<GenreTrack[]>(sql`
+				WITH canonical_occurrences AS (
+					SELECT dsl.target_song_spotify_id AS canonical_spotify_id, COUNT(sa.id)::int AS occurrences
+					FROM song_archive sa
+					JOIN songs raw ON raw.id = sa.song_id
+					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
+					GROUP BY dsl.target_song_spotify_id
+				),
+				song_artists AS (
+					SELECT DISTINCT lsa.song_id, a.id AS artist_id, a.name, a.spotify_id
+					FROM link_song_artists lsa
+					JOIN artists a ON a.id = lsa.artist_id
+				)
+				SELECT
+					s.name,
+					s.spotify_id,
+					array_agg(sa.artist_id ORDER BY sa.name) AS artist_ids,
+					array_agg(sa.name ORDER BY sa.name) AS artist_names,
+					array_agg(sa.spotify_id ORDER BY sa.name) AS artist_spotify_ids,
+					co.occurrences
+				FROM v_songs s
+				JOIN link_song_genres lsg ON lsg.song_id = s.id
+				JOIN canonical_occurrences co ON co.canonical_spotify_id = s.spotify_id
+				JOIN song_artists sa ON sa.song_id = s.id
+				WHERE lsg.genre_id = ${genreId}
+				GROUP BY s.id, s.name, s.spotify_id, co.occurrences
+				ORDER BY occurrences DESC
+				LIMIT 20
+			`),
+		connected_genres: range
+			? typed<ConnectedGenre[]>(sql`
+				WITH canonical_events AS (
+					SELECT dsl.target_song_spotify_id AS canonical_spotify_id, sa.created_at
+					FROM song_archive sa
+					JOIN songs raw ON raw.id = sa.song_id
+					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
+					WHERE sa.created_at >= to_timestamp(${range[0]})
+						AND sa.created_at <= to_timestamp(${range[1]})
+				),
+				artist_events AS (
+					SELECT lsa.artist_id, ce.created_at
+					FROM link_song_artists lsa
+					JOIN v_songs vs ON vs.id = lsa.song_id
+					JOIN canonical_events ce ON ce.canonical_spotify_id = vs.spotify_id
+				),
+				genre_pair_events AS (
+					SELECT lag1.genre_id AS source_genre_id, lag2.genre_id AS target_genre_id, ae.created_at
+					FROM link_artist_genres lag1
+					JOIN link_artist_genres lag2
+						ON lag2.artist_id = lag1.artist_id AND lag2.genre_id != lag1.genre_id
+					JOIN artist_events ae ON ae.artist_id = lag1.artist_id
+					WHERE lag1.genre_id = ${genreId}
+				)
+				SELECT g.id AS genre_id, g.name, COUNT(*)::int AS shared_archive_count
+				FROM genre_pair_events gpe
+				JOIN genres g ON g.id = gpe.target_genre_id
+				GROUP BY g.id, g.name
+				ORDER BY shared_archive_count DESC
+			`)
+			: typed<ConnectedGenre[]>(sql`
+				SELECT g.id AS genre_id, g.name, e.shared_archive_count
+				FROM genre_graph_edges e
+				JOIN genres g ON g.id = e.target_genre_id
+				WHERE e.source_genre_id = ${genreId}
+				UNION ALL
+				SELECT g.id AS genre_id, g.name, e.shared_archive_count
+				FROM genre_graph_edges e
+				JOIN genres g ON g.id = e.source_genre_id
+				WHERE e.target_genre_id = ${genreId}
+				ORDER BY shared_archive_count DESC
+			`),
 	});
 
 	if (genreRows.length === 0) {

--- a/web/src/routes/api/genres/[id]/+server.ts
+++ b/web/src/routes/api/genres/[id]/+server.ts
@@ -1,7 +1,7 @@
 import { neon } from "@neondatabase/serverless";
 import { json } from "@sveltejs/kit";
 import { allNamed, typed } from "$lib/allNamed";
-import { parseTimeRangeParams } from "$lib/graph";
+import { parseTimeRangeParams, sqlBounds } from "$lib/graph";
 import type { RequestHandler } from "./$types";
 
 export interface GenreArtist {
@@ -46,19 +46,13 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 
 	const sql = neon(dbUrl);
 	const range = parseTimeRangeParams(url.searchParams);
-	// `range[1]` names a whole second, but the graph_vertices/edges materialized
-	// views that produced it floor a sub-second `created_at` down to that
-	// second (extract(epoch ...)::bigint), so the archive row it's meant to
-	// include is very often a fraction of a second *after* it. Comparing with
-	// `< range[1] + 1` treats it as an inclusive whole-second bound instead of
-	// silently excluding the very row a default (all-time-derived) window was
-	// built around.
+	const bounds = range ? sqlBounds(range) : null;
 
 	const { genreRows, artists, tracks, connected_genres } = await allNamed({
 		genreRows: typed<{ name: string }[]>(sql`
 			SELECT name FROM genres WHERE id = ${genreId}
 		`),
-		artists: range
+		artists: bounds
 			? typed<GenreArtist[]>(sql`
 				SELECT a.id AS artist_id, a.name, a.spotify_id, COUNT(sa.id)::int AS archive_count
 				FROM artists a
@@ -66,8 +60,8 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 				JOIN link_song_artists lsa ON lsa.artist_id = a.id
 				JOIN song_archive sa ON sa.song_id = lsa.song_id
 				WHERE lag.genre_id = ${genreId}
-					AND sa.created_at >= to_timestamp(${range[0]})
-					AND sa.created_at < to_timestamp(${range[1] + 1})
+					AND sa.created_at >= to_timestamp(${bounds.start})
+					AND sa.created_at < to_timestamp(${bounds.endExclusive})
 				GROUP BY a.id, a.name, a.spotify_id
 				ORDER BY archive_count DESC
 				LIMIT 20
@@ -83,15 +77,15 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 				ORDER BY archive_count DESC
 				LIMIT 20
 			`),
-		tracks: range
+		tracks: bounds
 			? typed<GenreTrack[]>(sql`
 				WITH canonical_occurrences AS (
 					SELECT dsl.target_song_spotify_id AS canonical_spotify_id, COUNT(sa.id)::int AS occurrences
 					FROM song_archive sa
 					JOIN songs raw ON raw.id = sa.song_id
 					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
-					WHERE sa.created_at >= to_timestamp(${range[0]})
-						AND sa.created_at < to_timestamp(${range[1] + 1})
+					WHERE sa.created_at >= to_timestamp(${bounds.start})
+						AND sa.created_at < to_timestamp(${bounds.endExclusive})
 					GROUP BY dsl.target_song_spotify_id
 				),
 				song_artists AS (
@@ -144,15 +138,15 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 				ORDER BY occurrences DESC
 				LIMIT 20
 			`),
-		connected_genres: range
+		connected_genres: bounds
 			? typed<ConnectedGenre[]>(sql`
 				WITH canonical_events AS (
 					SELECT dsl.target_song_spotify_id AS canonical_spotify_id, sa.created_at
 					FROM song_archive sa
 					JOIN songs raw ON raw.id = sa.song_id
 					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
-					WHERE sa.created_at >= to_timestamp(${range[0]})
-						AND sa.created_at < to_timestamp(${range[1] + 1})
+					WHERE sa.created_at >= to_timestamp(${bounds.start})
+						AND sa.created_at < to_timestamp(${bounds.endExclusive})
 				),
 				artist_events AS (
 					SELECT lsa.artist_id, ce.created_at

--- a/web/src/routes/api/genres/[id]/+server.ts
+++ b/web/src/routes/api/genres/[id]/+server.ts
@@ -46,6 +46,13 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 
 	const sql = neon(dbUrl);
 	const range = parseTimeRangeParams(url.searchParams);
+	// `range[1]` names a whole second, but the graph_vertices/edges materialized
+	// views that produced it floor a sub-second `created_at` down to that
+	// second (extract(epoch ...)::bigint), so the archive row it's meant to
+	// include is very often a fraction of a second *after* it. Comparing with
+	// `< range[1] + 1` treats it as an inclusive whole-second bound instead of
+	// silently excluding the very row a default (all-time-derived) window was
+	// built around.
 
 	const { genreRows, artists, tracks, connected_genres } = await allNamed({
 		genreRows: typed<{ name: string }[]>(sql`
@@ -60,7 +67,7 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 				JOIN song_archive sa ON sa.song_id = lsa.song_id
 				WHERE lag.genre_id = ${genreId}
 					AND sa.created_at >= to_timestamp(${range[0]})
-					AND sa.created_at <= to_timestamp(${range[1]})
+					AND sa.created_at < to_timestamp(${range[1] + 1})
 				GROUP BY a.id, a.name, a.spotify_id
 				ORDER BY archive_count DESC
 				LIMIT 20
@@ -84,7 +91,7 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 					JOIN songs raw ON raw.id = sa.song_id
 					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
 					WHERE sa.created_at >= to_timestamp(${range[0]})
-						AND sa.created_at <= to_timestamp(${range[1]})
+						AND sa.created_at < to_timestamp(${range[1] + 1})
 					GROUP BY dsl.target_song_spotify_id
 				),
 				song_artists AS (
@@ -145,7 +152,7 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 					JOIN songs raw ON raw.id = sa.song_id
 					JOIN duplicate_song_lookup dsl ON dsl.source_song_spotify_id = raw.spotify_id
 					WHERE sa.created_at >= to_timestamp(${range[0]})
-						AND sa.created_at <= to_timestamp(${range[1]})
+						AND sa.created_at < to_timestamp(${range[1] + 1})
 				),
 				artist_events AS (
 					SELECT lsa.artist_id, ce.created_at

--- a/web/src/routes/galaxy/+page.svelte
+++ b/web/src/routes/galaxy/+page.svelte
@@ -317,6 +317,7 @@ function clearSelection(): void {
 	<GraphDetailDrawer
 		selected={selectedNode}
 		initialDetail={data.initialDetail}
+		{activeWindow}
 		onSelect={selectNode}
 		onClose={clearSelection}
 	/>


### PR DESCRIPTION
## Summary
- When a specific time range is active on the galaxy page, clicking a genre/artist node now filters and recomputes its drawer's lists (artists, tracks, related genres, collaborators) to that window instead of always showing all-time data.
- All-time mode ("All time" checkbox on) keeps the existing unfiltered behavior exactly as-is.
- The drawer shows a small "Showing <range>" note when windowed, and debounces refetches (250ms) so dragging the time slider doesn't flood the detail endpoints.
