### PR TITLE
Add artist and genre rankings (Issue #228)

### DIFF
--- a/cmd/migration_runner/runner.go
+++ b/cmd/migration_runner/runner.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	migrationsList = [13]*migrations.Migration{
+	migrationsList = [14]*migrations.Migration{
 		migrations.Migration001,
 		migrations.Migration002,
 		migrations.Migration003,
@@ -25,6 +25,7 @@ var (
 		migrations.Migration011,
 		migrations.Migration012,
 		migrations.Migration013,
+		migrations.Migration014,
 	}
 )
 

--- a/cmd/refresh_graph_mv/main.go
+++ b/cmd/refresh_graph_mv/main.go
@@ -42,5 +42,11 @@ func main() {
 	log.Info("Refreshing artist_graph_edges")
 	db.MustExec("REFRESH MATERIALIZED VIEW CONCURRENTLY artist_graph_edges")
 
+	log.Info("Refreshing artist_rank")
+	db.MustExec("REFRESH MATERIALIZED VIEW CONCURRENTLY artist_rank")
+
+	log.Info("Refreshing genre_rank")
+	db.MustExec("REFRESH MATERIALIZED VIEW CONCURRENTLY genre_rank")
+
 	log.Info("Successfully refreshed genre and artist graph materialized views")
 }

--- a/internal/persistence/postgres/migrations/migration014.go
+++ b/internal/persistence/postgres/migrations/migration014.go
@@ -1,0 +1,28 @@
+package migrations
+
+var Migration014 = &Migration{
+	Name: "014-ArtistGenreRankMaterializedViews",
+	Up: `
+		CREATE MATERIALIZED VIEW artist_rank AS
+		SELECT
+			artist_id,
+			RANK() OVER (ORDER BY archive_count DESC)::int AS rank,
+			COUNT(*) OVER ()::int AS total
+		FROM artist_graph_vertices;
+
+		CREATE UNIQUE INDEX artist_rank_artist_id_idx ON artist_rank (artist_id);
+
+		CREATE MATERIALIZED VIEW genre_rank AS
+		SELECT
+			genre_id,
+			RANK() OVER (ORDER BY archive_count DESC)::int AS rank,
+			COUNT(*) OVER ()::int AS total
+		FROM genre_graph_vertices;
+
+		CREATE UNIQUE INDEX genre_rank_genre_id_idx ON genre_rank (genre_id);
+	`,
+	Down: `
+		DROP MATERIALIZED VIEW IF EXISTS genre_rank;
+		DROP MATERIALIZED VIEW IF EXISTS artist_rank;
+	`,
+}

--- a/web/src/lib/ArtistDetailPanel.svelte
+++ b/web/src/lib/ArtistDetailPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import GenreChip from "$lib/GenreChip.svelte";
 import type { TimeRange } from "$lib/graph";
-import { formatWindowRange } from "$lib/graph";
+import { formatRank, formatWindowRange } from "$lib/graph";
 import SpotifyLinkPill from "$lib/SpotifyLinkPill.svelte";
 import { spotifyUrl } from "$lib/spotify";
 import type { ArtistDetail } from "../routes/api/artists/[id]/+server";
@@ -23,6 +23,7 @@ let {
 	<h2 class="title">{data.artist_name}</h2>
 	<SpotifyLinkPill type="artist" id={data.spotify_id} label="Open in Spotify" />
 </div>
+<p class="rank mono muted">{formatRank("artist", data.rank, data.rank_total)}</p>
 {#if activeWindow}
 	<p class="window-note mono muted">
 		Showing {formatWindowRange(activeWindow[0], activeWindow[1])}
@@ -112,9 +113,14 @@ let {
 		font-size: 20px;
 	}
 
-	.window-note {
+	.rank {
 		font-size: 11px;
 		margin: -0.75rem 0 1.25rem;
+	}
+
+	.window-note {
+		font-size: 11px;
+		margin: -1rem 0 1.25rem;
 	}
 
 	.block {

--- a/web/src/lib/GenreDetailPanel.svelte
+++ b/web/src/lib/GenreDetailPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import GenreChip from "$lib/GenreChip.svelte";
 import type { TimeRange } from "$lib/graph";
-import { formatWindowRange } from "$lib/graph";
+import { formatRank, formatWindowRange } from "$lib/graph";
 import { spotifyUrl } from "$lib/spotify";
 import type { GenreDetail } from "../routes/api/genres/[id]/+server";
 
@@ -19,6 +19,7 @@ let {
 </script>
 
 <h2 class="title">{data.genre_name}</h2>
+<p class="rank mono muted">{formatRank("genre", data.rank, data.rank_total)}</p>
 {#if activeWindow}
 	<p class="window-note mono muted">
 		Showing {formatWindowRange(activeWindow[0], activeWindow[1])}
@@ -116,6 +117,11 @@ let {
 	.title {
 		font-size: 20px;
 		margin-bottom: 1.25rem;
+	}
+
+	.rank {
+		font-size: 11px;
+		margin: -1rem 0 1.25rem;
 	}
 
 	.window-note {

--- a/web/src/lib/graph.test.ts
+++ b/web/src/lib/graph.test.ts
@@ -6,6 +6,7 @@ import {
 	detailFetchUrl,
 	edgeOpacity,
 	edgeWidth,
+	formatRank,
 	formatWindowRange,
 	isolatedNodePosition,
 	nodeSize,
@@ -78,6 +79,22 @@ describe("formatWindowRange", () => {
 		const start = new Date(2026, 0, 1).getTime() / 1000;
 		const end = new Date(2026, 0, 2).getTime() / 1000;
 		expect(formatWindowRange(start, end)).toContain(" – ");
+	});
+});
+
+describe("formatRank", () => {
+	it("produces the correct artist string", () => {
+		expect(formatRank("artist", 1, 629)).toBe("Artist Rank: 1 out of 629");
+	});
+
+	it("produces the correct genre string", () => {
+		expect(formatRank("genre", 12, 340)).toBe("Genre Rank: 12 out of 340");
+	});
+
+	it("formats large totals with thousands separators", () => {
+		expect(formatRank("artist", 1000, 12345)).toBe(
+			"Artist Rank: 1,000 out of 12,345",
+		);
 	});
 });
 

--- a/web/src/lib/graph.ts
+++ b/web/src/lib/graph.ts
@@ -38,6 +38,18 @@ export function formatWindowRange(
 	return `${day.format(start)} – ${dayWithYear.format(end)}`;
 }
 
+// Formats the detail-drawer rank line, e.g. "Artist Rank: 1 out of 629".
+// Rank is always all-time (see artist_rank/genre_rank materialized views) —
+// it does not change when the galaxy page's time-window filter is active.
+export function formatRank(
+	kind: "artist" | "genre",
+	rank: number,
+	total: number,
+): string {
+	const label = kind === "artist" ? "Artist Rank" : "Genre Rank";
+	return `${label}: ${rank.toLocaleString()} out of ${total.toLocaleString()}`;
+}
+
 // Log-scale node diameter
 export function nodeSize(count: number, maxCount: number): number {
 	return 14 + 50 * (Math.log(count + 1) / Math.log(maxCount + 1));

--- a/web/src/lib/mixed-graph.ts
+++ b/web/src/lib/mixed-graph.ts
@@ -82,7 +82,7 @@ export function buildMixedGraph(
 
 	for (const v of genreVertices) {
 		graph.addNode(genreNodeId(v.genre_id), {
-			label: v.name,
+			label: `${v.name} (#${v.rank})`,
 			kind: "genre" satisfies NodeKind,
 			genreId: v.genre_id,
 			archiveCount: v.archive_count,
@@ -92,7 +92,7 @@ export function buildMixedGraph(
 
 	for (const v of artistVertices) {
 		graph.addNode(artistNodeId(v.artist_id), {
-			label: v.name,
+			label: `${v.name} (#${v.rank})`,
 			kind: "artist" satisfies NodeKind,
 			artistId: v.artist_id,
 			archiveCount: v.archive_count,

--- a/web/src/routes/api/artists/[id]/+server.ts
+++ b/web/src/routes/api/artists/[id]/+server.ts
@@ -30,6 +30,8 @@ export interface ArtistDetail {
 	songs: ArtistSong[];
 	genres: ArtistGenre[];
 	connected_artists: ConnectedArtist[];
+	rank: number;
+	rank_total: number;
 }
 
 export const GET: RequestHandler = async ({ platform, params, url }) => {
@@ -47,9 +49,12 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 	const range = parseTimeRangeParams(url.searchParams);
 	const bounds = range ? sqlBounds(range) : null;
 
-	const { artistRows, songs, genres, connected_artists } = await allNamed({
+	const { artistRows, rankRows, songs, genres, connected_artists } = await allNamed({
 		artistRows: typed<{ name: string; spotify_id: string }[]>(sql`
 			SELECT name, spotify_id FROM artists WHERE id = ${artistId}
+		`),
+		rankRows: typed<{ rank: number; total: number }[]>(sql`
+			SELECT rank, total FROM artist_rank WHERE artist_id = ${artistId}
 		`),
 		songs: bounds
 			? typed<ArtistSong[]>(sql`
@@ -181,5 +186,7 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 		songs,
 		genres,
 		connected_artists,
+		rank: rankRows[0].rank,
+		rank_total: rankRows[0].total,
 	} satisfies ArtistDetail);
 };

--- a/web/src/routes/api/genres/[id]/+server.ts
+++ b/web/src/routes/api/genres/[id]/+server.ts
@@ -31,6 +31,8 @@ export interface GenreDetail {
 	artists: GenreArtist[];
 	tracks: GenreTrack[];
 	connected_genres: ConnectedGenre[];
+	rank: number;
+	rank_total: number;
 }
 
 export const GET: RequestHandler = async ({ platform, params, url }) => {
@@ -48,9 +50,12 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 	const range = parseTimeRangeParams(url.searchParams);
 	const bounds = range ? sqlBounds(range) : null;
 
-	const { genreRows, artists, tracks, connected_genres } = await allNamed({
+	const { genreRows, rankRows, artists, tracks, connected_genres } = await allNamed({
 		genreRows: typed<{ name: string }[]>(sql`
 			SELECT name FROM genres WHERE id = ${genreId}
+		`),
+		rankRows: typed<{ rank: number; total: number }[]>(sql`
+			SELECT rank, total FROM genre_rank WHERE genre_id = ${genreId}
 		`),
 		artists: bounds
 			? typed<GenreArtist[]>(sql`
@@ -191,5 +196,7 @@ export const GET: RequestHandler = async ({ platform, params, url }) => {
 		artists,
 		tracks,
 		connected_genres,
+		rank: rankRows[0].rank,
+		rank_total: rankRows[0].total,
 	} satisfies GenreDetail);
 };

--- a/web/src/routes/api/graph/+server.ts
+++ b/web/src/routes/api/graph/+server.ts
@@ -9,6 +9,7 @@ export interface GenreVertex {
 	name: string;
 	archive_count: number;
 	ranges: TimeRange[];
+	rank: number;
 }
 
 export interface ArtistVertex {
@@ -16,6 +17,7 @@ export interface ArtistVertex {
 	name: string;
 	archive_count: number;
 	ranges: TimeRange[];
+	rank: number;
 }
 
 export interface GenreGenreEdge {
@@ -57,14 +59,16 @@ export const GET: RequestHandler = async ({ platform }) => {
 
 	const data = await allNamed({
 		genreVertices: typed<GenreVertex[]>(sql`
-			SELECT genre_id, name, archive_count, ranges
-			FROM genre_graph_vertices
-			ORDER BY archive_count DESC
+			SELECT gv.genre_id, gv.name, gv.archive_count, gv.ranges, gr.rank
+			FROM genre_graph_vertices gv
+			JOIN genre_rank gr ON gr.genre_id = gv.genre_id
+			ORDER BY gv.archive_count DESC
 		`),
 		artistVertices: typed<ArtistVertex[]>(sql`
-			SELECT artist_id, name, archive_count, ranges
-			FROM artist_graph_vertices
-			ORDER BY archive_count DESC
+			SELECT av.artist_id, av.name, av.archive_count, av.ranges, ar.rank
+			FROM artist_graph_vertices av
+			JOIN artist_rank ar ON ar.artist_id = av.artist_id
+			ORDER BY av.archive_count DESC
 		`),
 		genreGenreEdges: typed<GenreGenreEdge[]>(sql`
 			SELECT source_genre_id, target_genre_id, shared_archive_count, ranges


### PR DESCRIPTION
## Summary
- Adds `artist_rank`/`genre_rank` materialized views (migration014) built on top of the existing `artist_graph_vertices`/`genre_graph_vertices` views, computing an all-time `RANK() OVER (ORDER BY archive_count DESC)` plus a total count — precomputed rather than calculated per request.
- Wires the new views into `cmd/migration_runner` and the 6-hour `cmd/refresh_graph_mv` cron job.
- Surfaces `rank`/`rank_total` from `/api/artists/:id` and `/api/genres/:id`, and renders "Artist Rank: X out of Y" / "Genre Rank: X out of Y" under the title in the Galaxy detail panels — always all-time, unaffected by the time-window filter.
- Also appends the rank to each node's label directly on the Galaxy graph (e.g. `Jamie xx (#3)`, `melodic house (#1)`).

Closes #228.
