### PR TITLE
fix(galaxy): full-width layout and left-align wrapped artist names

### DIFF
--- a/web/src/lib/ArtistDetailPanel.svelte
+++ b/web/src/lib/ArtistDetailPanel.svelte
@@ -200,6 +200,7 @@ let {
 		border: none;
 		padding: 0;
 		font: inherit;
+		text-align: left;
 		cursor: pointer;
 		color: var(--text);
 		transition: color 0.15s;

--- a/web/src/lib/GenreDetailPanel.svelte
+++ b/web/src/lib/GenreDetailPanel.svelte
@@ -193,6 +193,7 @@ let {
 		border: none;
 		padding: 0;
 		font: inherit;
+		text-align: left;
 		cursor: pointer;
 		color: var(--text);
 		transition: color 0.15s;

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 import "../app.css";
+import { page } from "$app/state";
 
 let { children } = $props();
+
+const fullBleed = $derived(page.url.pathname.startsWith("/galaxy"));
 </script>
 
 <svelte:head>
@@ -24,7 +27,7 @@ let { children } = $props();
 	</div>
 </header>
 
-<main>
+<main class:full-bleed={fullBleed}>
 	{@render children()}
 </main>
 
@@ -94,6 +97,10 @@ let { children } = $props();
 		max-width: 1400px;
 		margin: 0 auto;
 		padding: 2rem;
+	}
+
+	main.full-bleed {
+		max-width: none;
 	}
 
 	footer {


### PR DESCRIPTION
## Summary
- Galaxy page (`/galaxy`) now spans the full viewport width instead of being capped by the shared 1400px `main` container.
- Artist name buttons in the genre/artist detail drawer's tracks tables now left-align instead of inheriting the browser's default centered `<button>` text-align, so wrapped names (e.g. "Red Hot Chili Peppers") no longer look oddly centered.
